### PR TITLE
Offload parsing to Worker Thread for better performance

### DIFF
--- a/daedalus-dialog-editor/src/main/services/ParserService.ts
+++ b/daedalus-dialog-editor/src/main/services/ParserService.ts
@@ -1,41 +1,54 @@
-import Parser from 'tree-sitter';
-import { SemanticModelBuilderVisitor } from 'daedalus-parser/semantic-visitor';
-
-// @ts-ignore - CommonJS module
-const DaedalusParser = require('daedalus-parser');
-const Daedalus = DaedalusParser.DaedalusLanguage;
+import { Worker } from 'worker_threads';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
 
 export class ParserService {
-  private parser: Parser;
+  private worker: Worker;
+  private pendingRequests: Map<string, { resolve: (value: any) => void; reject: (reason?: any) => void }>;
 
   constructor() {
-    this.parser = new Parser();
-    this.parser.setLanguage(Daedalus);
+    this.pendingRequests = new Map();
+
+    // Worker is located at ../workers/parser.worker.js relative to this file
+    // This works because both files are compiled to the same relative structure in dist/main
+    const workerPath = path.join(__dirname, '../workers/parser.worker.js');
+
+    this.worker = new Worker(workerPath);
+
+    this.worker.on('message', (message: { id: string; result?: any; error?: string }) => {
+      const { id, result, error } = message;
+      const pending = this.pendingRequests.get(id);
+
+      if (pending) {
+        if (error) {
+          pending.reject(new Error(error));
+        } else {
+          pending.resolve(result);
+        }
+        this.pendingRequests.delete(id);
+      }
+    });
+
+    this.worker.on('error', (err) => {
+        console.error('Parser Worker error:', err);
+    });
+
+    this.worker.on('exit', (code) => {
+        if (code !== 0) {
+            console.error(`Parser Worker stopped with exit code ${code}`);
+        }
+    });
   }
 
   /**
-   * Parse Daedalus source code and return semantic model
-   * Returns a plain serializable object (no class instances with methods)
-   * If syntax errors are detected, returns model with hasErrors: true and errors array
+   * Parse Daedalus source code and return semantic model asynchronously
+   * Offloads parsing to a worker thread to avoid blocking the main process
    */
-  parseSource(sourceCode: string): any {
-    const tree = this.parser.parse(sourceCode);
-
-    const visitor = new SemanticModelBuilderVisitor();
-
-    // Check for syntax errors first
-    visitor.checkForSyntaxErrors(tree.rootNode as any, sourceCode);
-
-    // If there are syntax errors, return the model with errors immediately
-    if (visitor.semanticModel.hasErrors) {
-      return visitor.semanticModel;
-    }
-
-    // Otherwise, proceed with semantic analysis
-    visitor.pass1_createObjects(tree.rootNode as any);
-    visitor.pass2_analyzeAndLink(tree.rootNode as any);
-
-    // Return the semantic model - it's serializable (plain objects)
-    return visitor.semanticModel;
+  async parseSource(sourceCode: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const id = randomUUID();
+      this.pendingRequests.set(id, { resolve, reject });
+      this.worker.postMessage({ id, sourceCode });
+    });
   }
 }

--- a/daedalus-dialog-editor/src/main/services/ValidationService.ts
+++ b/daedalus-dialog-editor/src/main/services/ValidationService.ts
@@ -106,7 +106,7 @@ export class ValidationService {
 
     // Step 2: Syntax validation via round-trip parsing
     if (!options.skipSyntaxValidation) {
-      const syntaxErrors = this.validateSyntax(generatedCode);
+      const syntaxErrors = await this.validateSyntax(generatedCode);
       errors.push(...syntaxErrors);
     }
 
@@ -140,11 +140,11 @@ export class ValidationService {
   /**
    * Validate generated code by parsing it back
    */
-  private validateSyntax(code: string): ValidationError[] {
+  private async validateSyntax(code: string): Promise<ValidationError[]> {
     const errors: ValidationError[] = [];
 
     try {
-      const parseResult = this.parserService.parseSource(code);
+      const parseResult = await this.parserService.parseSource(code);
 
       if (parseResult.hasErrors && parseResult.errors) {
         for (const parseError of parseResult.errors) {

--- a/daedalus-dialog-editor/src/main/workers/parser.worker.ts
+++ b/daedalus-dialog-editor/src/main/workers/parser.worker.ts
@@ -1,0 +1,43 @@
+import { parentPort } from 'worker_threads';
+import Parser from 'tree-sitter';
+import { SemanticModelBuilderVisitor } from 'daedalus-parser/semantic-visitor';
+
+// @ts-ignore - CommonJS module
+const DaedalusParser = require('daedalus-parser');
+const Daedalus = DaedalusParser.DaedalusLanguage;
+
+const parser = new Parser();
+parser.setLanguage(Daedalus);
+
+if (parentPort) {
+  parentPort.on('message', (message: { id: string; sourceCode: string }) => {
+    try {
+      const { id, sourceCode } = message;
+
+      // Perform parsing
+      const tree = parser.parse(sourceCode);
+      const visitor = new SemanticModelBuilderVisitor();
+
+      // Check for syntax errors first
+      visitor.checkForSyntaxErrors(tree.rootNode as any, sourceCode);
+
+      // If there are syntax errors, return the model with errors immediately
+      if (visitor.semanticModel.hasErrors) {
+        parentPort!.postMessage({ id, result: visitor.semanticModel });
+        return;
+      }
+
+      // Otherwise, proceed with semantic analysis
+      visitor.pass1_createObjects(tree.rootNode as any);
+      visitor.pass2_analyzeAndLink(tree.rootNode as any);
+
+      // Return the semantic model
+      parentPort!.postMessage({ id, result: visitor.semanticModel });
+    } catch (error) {
+      parentPort!.postMessage({
+        id: message.id,
+        error: error instanceof Error ? error.message : 'Unknown worker error'
+      });
+    }
+  });
+}

--- a/daedalus-dialog-editor/tests/ValidationService.test.ts
+++ b/daedalus-dialog-editor/tests/ValidationService.test.ts
@@ -35,7 +35,7 @@ describe('ValidationService', () => {
 
     // Default successful behavior
     mockGenerateCode.mockReturnValue('// Generated code');
-    mockParseSource.mockReturnValue({
+    mockParseSource.mockResolvedValue({
       dialogs: {},
       functions: {},
       hasErrors: false,
@@ -70,7 +70,7 @@ describe('ValidationService', () => {
       };
 
       mockGenerateCode.mockReturnValue('FUNC INT DIA_Test_Condition() { return TRUE; };');
-      mockParseSource.mockReturnValue({ hasErrors: false, errors: [] });
+      mockParseSource.mockResolvedValue({ hasErrors: false, errors: [] });
 
       const result = await validationService.validate(validModel, defaultSettings);
 
@@ -97,7 +97,7 @@ describe('ValidationService', () => {
       };
 
       mockGenerateCode.mockReturnValue('FUNC VOID BrokenFunc() { broken };');
-      mockParseSource.mockReturnValue({
+      mockParseSource.mockResolvedValue({
         hasErrors: true,
         errors: [
           { type: 'syntax_error', message: 'Unexpected token', position: { row: 0, column: 25 } }


### PR DESCRIPTION
- Created `daedalus-dialog-editor/src/main/workers/parser.worker.ts` to handle parsing in a separate thread.
- Updated `ParserService` to manage the worker and handle async communication.
- Updated `ValidationService` to await `ParserService.parseSource`.
- Updated `ValidationService.test.ts` to mock async `parseSource`.
- Verified all tests pass.

---
*PR created automatically by Jules for task [2347642506726362368](https://jules.google.com/task/2347642506726362368) started by @daniel-daga*