### PR TITLE
⚡ Bolt: Optimize DialogTreeItem re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-02-01 - Monolithic State vs React Memoization
+**Learning:** The `semanticModel` object is a large monolithic state that is recreated on every edit. Passing this entire object to list items like `DialogTreeItem` defeats `React.memo` unless a custom comparator is used to check only relevant sub-properties. Furthermore, callbacks like `buildFunctionTree` that depend on the entire model will break memoization of child components.
+**Action:** When working with `semanticModel`, extract stable sub-properties (like `functions` map) for dependencies, and use granular checks in `React.memo` comparators to avoid O(N) re-renders on single-item updates.

--- a/daedalus-dialog-editor/src/renderer/components/DialogTreeItem.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/DialogTreeItem.tsx
@@ -109,7 +109,19 @@ const DialogTreeItem = memo(({
   );
 }, (prev, next) => {
   if (prev.dialogName !== next.dialogName) return false;
-  if (prev.semanticModel !== next.semanticModel) return false;
+
+  // Optimization: specific check for relevant semantic model parts
+  // 1. Check if specific dialog object changed
+  const prevDialog = prev.semanticModel.dialogs?.[prev.dialogName];
+  const nextDialog = next.semanticModel.dialogs?.[next.dialogName];
+  if (prevDialog !== nextDialog) return false;
+
+  // 2. Check if functions map changed (needed for info function lookup)
+  if (prev.semanticModel.functions !== next.semanticModel.functions) return false;
+
+  // 3. Check if tree builder changed (it depends on functions)
+  if (prev.buildFunctionTree !== next.buildFunctionTree) return false;
+
   if (prev.isSelected !== next.isSelected) return false;
   if (prev.isExpanded !== next.isExpanded) return false;
   if (prev.selectedFunctionName !== next.selectedFunctionName) return false;

--- a/daedalus-dialog-editor/src/renderer/components/ThreeColumnLayout.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/ThreeColumnLayout.tsx
@@ -131,6 +131,7 @@ const ThreeColumnLayout: React.FC<ThreeColumnLayoutProps> = ({ filePath }) => {
   // Build function tree for a given function (recursively find choices)
   // ancestorPath tracks the path from root to current node to prevent direct cycles
   // Uses memoization to prevent exponential recomputation in diamond patterns
+  const functions = semanticModel.functions;
   const buildFunctionTree = useCallback((funcName: string, ancestorPath: string[] = []): FunctionTreeNode | null => {
     // Prevent direct cycles (A -> B -> A), but allow diamonds (A -> B, A -> C, both -> D)
     if (ancestorPath.includes(funcName)) {
@@ -146,7 +147,7 @@ const ThreeColumnLayout: React.FC<ThreeColumnLayoutProps> = ({ filePath }) => {
       return cached;
     }
 
-    const func = semanticModel.functions?.[funcName];
+    const func = functions?.[funcName];
     if (!func) return null;
 
     // Filter actions that are choices (have dialogRef and targetFunction)
@@ -185,7 +186,7 @@ const ThreeColumnLayout: React.FC<ThreeColumnLayoutProps> = ({ filePath }) => {
     lruCacheSet(cacheKey, result);
 
     return result;
-  }, [semanticModel, lruCacheGet, lruCacheSet]);
+  }, [functions, lruCacheGet, lruCacheSet]);
 
   // Memoize NPC map extraction to avoid rebuilding on every render
   // In project mode, use project NPCs; in single-file mode, extract from file


### PR DESCRIPTION
💡 What: Optimized `DialogTreeItem` memoization and `buildFunctionTree` dependency.
🎯 Why: `DialogTreeItem` was re-rendering for all items whenever `semanticModel` updated, even if the specific dialog didn't change. This was due to `semanticModel` reference equality check.
📊 Impact: Expected to reduce re-renders significantly (O(1) updates instead of O(N)) when editing a single dialog in a large list.
🔬 Measurement: Verified by code inspection and ensuring tests pass.

---
*PR created automatically by Jules for task [2199778621399586280](https://jules.google.com/task/2199778621399586280) started by @daniel-daga*