### PR TITLE
Support Global Constants and Variables in Daedalus Parser

### DIFF
--- a/daedalus-parser/src/semantic/semantic-model.ts
+++ b/daedalus-parser/src/semantic/semantic-model.ts
@@ -23,6 +23,36 @@ export interface TreeSitterNode {
 // SEMANTIC MODEL CLASSES
 // ===================================================================
 
+export class GlobalConstant {
+  public name: string;
+  public type: string;
+  public value: string | number | boolean;
+
+  constructor(name: string, type: string, value: string | number | boolean) {
+    this.name = name;
+    this.type = type;
+    this.value = value;
+  }
+
+  static fromJSON(json: any): GlobalConstant {
+    return new GlobalConstant(json.name, json.type, json.value);
+  }
+}
+
+export class GlobalVariable {
+  public name: string;
+  public type: string;
+
+  constructor(name: string, type: string) {
+    this.name = name;
+    this.type = type;
+  }
+
+  static fromJSON(json: any): GlobalVariable {
+    return new GlobalVariable(json.name, json.type);
+  }
+}
+
 export interface DialogProperties {
   [key: string]: string | number | boolean | DialogFunction;
 }
@@ -604,6 +634,8 @@ export interface SyntaxError {
 export interface SemanticModel {
   dialogs: { [key: string]: Dialog };
   functions: { [key: string]: DialogFunction };
+  constants?: { [key: string]: GlobalConstant };
+  variables?: { [key: string]: GlobalVariable };
   errors?: SyntaxError[];
   hasErrors?: boolean;
 }
@@ -613,6 +645,8 @@ export function deserializeSemanticModel(json: any): SemanticModel {
   const model: SemanticModel = {
     dialogs: {},
     functions: {},
+    constants: {},
+    variables: {},
     errors: json.errors,
     hasErrors: json.hasErrors
   };
@@ -625,6 +659,20 @@ export function deserializeSemanticModel(json: any): SemanticModel {
   // 2. Reconstruct dialogs and link to functions
   for (const dialogName in json.dialogs) {
     model.dialogs[dialogName] = Dialog.fromJSON(json.dialogs[dialogName], model.functions);
+  }
+
+  // 3. Reconstruct constants
+  if (json.constants) {
+    for (const key in json.constants) {
+      model.constants![key] = GlobalConstant.fromJSON(json.constants[key]);
+    }
+  }
+
+  // 4. Reconstruct variables
+  if (json.variables) {
+    for (const key in json.variables) {
+      model.variables![key] = GlobalVariable.fromJSON(json.variables[key]);
+    }
   }
 
   return model;

--- a/daedalus-parser/test/semantic-global-symbols.test.js
+++ b/daedalus-parser/test/semantic-global-symbols.test.js
@@ -1,0 +1,71 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { parseSemanticModel } = require('../dist/semantic/semantic-visitor-index');
+
+test('should parse global constants', () => {
+  const source = `
+    const string TOPIC_MyQuest = "The Lost Sheep";
+    const int MAX_GOLD = 1000;
+  `;
+
+  const model = parseSemanticModel(source);
+
+  assert.equal(model.hasErrors, false, 'Should parse without errors');
+
+  // Check constants
+  assert.ok(model.constants, 'Model should have constants map');
+
+  const topicConst = model.constants['TOPIC_MyQuest'];
+  assert.ok(topicConst, 'Should find TOPIC_MyQuest constant');
+  assert.equal(topicConst.name, 'TOPIC_MyQuest');
+  assert.equal(topicConst.type, 'string');
+  assert.equal(topicConst.value, '"The Lost Sheep"');
+
+  const goldConst = model.constants['MAX_GOLD'];
+  assert.ok(goldConst, 'Should find MAX_GOLD constant');
+  assert.equal(goldConst.name, 'MAX_GOLD');
+  assert.equal(goldConst.type, 'int');
+  assert.equal(goldConst.value, 1000);
+});
+
+test('should parse global variables', () => {
+  const source = `
+    var int MIS_MyQuest;
+    var string CurrentLevel;
+  `;
+
+  const model = parseSemanticModel(source);
+
+  assert.equal(model.hasErrors, false, 'Should parse without errors');
+
+  // Check variables
+  assert.ok(model.variables, 'Model should have variables map');
+
+  const questVar = model.variables['MIS_MyQuest'];
+  assert.ok(questVar, 'Should find MIS_MyQuest variable');
+  assert.equal(questVar.name, 'MIS_MyQuest');
+  assert.equal(questVar.type, 'int');
+
+  const levelVar = model.variables['CurrentLevel'];
+  assert.ok(levelVar, 'Should find CurrentLevel variable');
+  assert.equal(levelVar.name, 'CurrentLevel');
+  assert.equal(levelVar.type, 'string');
+});
+
+test('should handle mixed global declarations', () => {
+    const source = `
+      const string TOPIC_Test = "Test Quest";
+      var int MIS_Test;
+
+      func void TestFunc() {
+        return;
+      };
+    `;
+
+    const model = parseSemanticModel(source);
+
+    assert.equal(model.hasErrors, false);
+    assert.ok(model.constants['TOPIC_Test']);
+    assert.ok(model.variables['MIS_Test']);
+    assert.ok(model.functions['TestFunc']);
+});

--- a/daedalus-parser/test/semantic-serialization.test.js
+++ b/daedalus-parser/test/semantic-serialization.test.js
@@ -109,3 +109,34 @@ test('deserializeSemanticModel should handle various action types', () => {
   assert.ok(actions[1] instanceof Choice);
   assert.equal(actions[1].text, 'Option 1');
 });
+
+test('deserializeSemanticModel should handle global constants and variables', () => {
+  const plainJson = {
+    functions: {},
+    dialogs: {},
+    constants: {
+      'TOPIC_Test': {
+        name: 'TOPIC_Test',
+        type: 'string',
+        value: 'Test Topic'
+      }
+    },
+    variables: {
+      'MIS_Test': {
+        name: 'MIS_Test',
+        type: 'int'
+      }
+    }
+  };
+
+  const model = deserializeSemanticModel(plainJson);
+  const { GlobalConstant, GlobalVariable } = require('../dist/semantic/semantic-visitor-index');
+
+  assert.ok(model.constants['TOPIC_Test'] instanceof GlobalConstant);
+  assert.equal(model.constants['TOPIC_Test'].name, 'TOPIC_Test');
+  assert.equal(model.constants['TOPIC_Test'].value, 'Test Topic');
+
+  assert.ok(model.variables['MIS_Test'] instanceof GlobalVariable);
+  assert.equal(model.variables['MIS_Test'].name, 'MIS_Test');
+  assert.equal(model.variables['MIS_Test'].type, 'int');
+});


### PR DESCRIPTION
Extended the Daedalus parser's semantic model to support parsing and storing global constants and variables. This is a prerequisite for the Quest Editor features, which rely on analyzing `TOPIC_*` constants and `MIS_*` variables.
- Modified `semantic-model.ts` to include `GlobalConstant` and `GlobalVariable` entities.
- Updated `SemanticModelBuilderVisitor` to capture `variable_declaration` nodes during the first pass.
- Added comprehensive tests for the new functionality.

---
*PR created automatically by Jules for task [12466052077736426227](https://jules.google.com/task/12466052077736426227) started by @daniel-daga*