### PR TITLE
Initialize Quest Editor UI

### DIFF
--- a/daedalus-dialog-editor/src/renderer/App.tsx
+++ b/daedalus-dialog-editor/src/renderer/App.tsx
@@ -4,7 +4,7 @@ import { FolderOpen as FolderOpenIcon, Folder as FolderIcon, Save as SaveIcon } 
 import { useEditorStore } from './store/editorStore';
 import { useProjectStore } from './store/projectStore';
 import { useAutoSave } from './hooks/useAutoSave';
-import ThreeColumnLayout from './components/ThreeColumnLayout';
+import MainLayout from './components/MainLayout';
 import ErrorBoundary from './components/ErrorBoundary';
 
 const App: React.FC = () => {
@@ -82,7 +82,7 @@ const App: React.FC = () => {
       <Box sx={{ flexGrow: 1, display: 'flex', overflow: 'hidden' }}>
         <ErrorBoundary>
           {activeFile || projectPath ? (
-            <ThreeColumnLayout filePath={activeFile} />
+            <MainLayout filePath={activeFile} />
           ) : (
           <Box sx={{
             flex: 1,

--- a/daedalus-dialog-editor/src/renderer/components/MainLayout.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/MainLayout.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { Box, ToggleButton, ToggleButtonGroup, Paper, Tooltip } from '@mui/material';
+import { Chat as ChatIcon, Book as BookIcon } from '@mui/icons-material';
+import ThreeColumnLayout from './ThreeColumnLayout';
+import QuestEditor from './QuestEditor';
+import { useEditorStore } from '../store/editorStore';
+import { useProjectStore } from '../store/projectStore';
+import type { SemanticModel } from '../types/global';
+
+interface MainLayoutProps {
+  filePath: string | null;
+}
+
+const MainLayout: React.FC<MainLayoutProps> = ({ filePath }) => {
+  const [view, setView] = useState<'dialog' | 'quest'>('dialog');
+  const { openFiles } = useEditorStore();
+  const { projectPath, mergedSemanticModel } = useProjectStore();
+
+  const fileState = filePath ? openFiles.get(filePath) : null;
+  const isProjectMode = !!projectPath;
+  const semanticModel = isProjectMode ? mergedSemanticModel : (fileState?.semanticModel || {});
+
+  return (
+    <Box sx={{ display: 'flex', height: '100%', width: '100%' }}>
+      {/* Sidebar Navigation */}
+      <Paper square elevation={2} sx={{ width: 60, display: 'flex', flexDirection: 'column', alignItems: 'center', pt: 2, zIndex: 10, borderRight: 1, borderColor: 'divider' }}>
+         <ToggleButtonGroup
+            orientation="vertical"
+            value={view}
+            exclusive
+            onChange={(_, newView) => newView && setView(newView)}
+            sx={{ '& .MuiToggleButton-root': { mb: 1, border: 'none', borderRadius: 2 } }}
+         >
+            <Tooltip title="Dialog Editor" placement="right">
+                <ToggleButton value="dialog" aria-label="Dialog Editor">
+                    <ChatIcon />
+                </ToggleButton>
+            </Tooltip>
+            <Tooltip title="Quest Editor" placement="right">
+                <ToggleButton value="quest" aria-label="Quest Editor">
+                    <BookIcon />
+                </ToggleButton>
+            </Tooltip>
+         </ToggleButtonGroup>
+      </Paper>
+
+      {/* Main Content */}
+      <Box sx={{ flexGrow: 1, overflow: 'hidden' }}>
+         {/* We use Box with display toggle to preserve state of ThreeColumnLayout when switching views */}
+         <Box sx={{ display: view === 'dialog' ? 'block' : 'none', height: '100%' }}>
+             <ThreeColumnLayout filePath={filePath} />
+         </Box>
+
+         {view === 'quest' && (
+             <Box sx={{ height: '100%' }}>
+                 <QuestEditor semanticModel={semanticModel as SemanticModel} />
+             </Box>
+         )}
+      </Box>
+    </Box>
+  );
+};
+
+export default MainLayout;

--- a/daedalus-dialog-editor/src/renderer/components/QuestDetails.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestDetails.tsx
@@ -1,0 +1,144 @@
+import React, { useMemo } from 'react';
+import { Box, Typography, Paper, Chip, Stack, List, ListItem, ListItemText, Divider } from '@mui/material';
+import type { SemanticModel } from '../types/global';
+import { getActionType } from './actionTypes';
+
+interface QuestDetailsProps {
+  semanticModel: SemanticModel;
+  questName: string | null;
+}
+
+interface QuestReference {
+  type: 'create' | 'status' | 'entry';
+  dialogName?: string;
+  functionName: string;
+  npcName?: string;
+  details: string;
+}
+
+const QuestDetails: React.FC<QuestDetailsProps> = ({ semanticModel, questName }) => {
+  if (!questName) {
+    return (
+      <Box sx={{ p: 3, display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+        <Typography color="text.secondary">Select a quest to view details</Typography>
+      </Box>
+    );
+  }
+
+  const questConstant = semanticModel.constants?.[questName];
+  const misVarName = questName.replace('TOPIC_', 'MIS_');
+  const misVariable = semanticModel.variables?.[misVarName];
+
+  const references = useMemo(() => {
+    const refs: QuestReference[] = [];
+
+    // Map functions to dialogs for better context
+    const funcToDialog = new Map<string, { dialogName: string, npcName?: string }>();
+    Object.values(semanticModel.dialogs || {}).forEach(dialog => {
+        const info = dialog.properties.information;
+        if (typeof info === 'string') {
+            funcToDialog.set(info, { dialogName: dialog.name, npcName: dialog.properties.npc });
+        } else if (info && typeof info === 'object' && info.name) {
+             funcToDialog.set(info.name, { dialogName: dialog.name, npcName: dialog.properties.npc });
+        }
+    });
+
+    Object.values(semanticModel.functions || {}).forEach(func => {
+        func.actions?.forEach(action => {
+            if ('topic' in action && action.topic === questName) {
+                const context = funcToDialog.get(func.name) || { };
+                const type = getActionType(action);
+
+                if (type === 'createTopic') {
+                     refs.push({
+                        type: 'create',
+                        functionName: func.name,
+                        dialogName: context.dialogName,
+                        npcName: context.npcName,
+                        details: `Created${(action as any).topicType ? ` in ${(action as any).topicType}` : ''}`
+                     });
+                } else if (type === 'logSetTopicStatus') {
+                     refs.push({
+                        type: 'status',
+                        functionName: func.name,
+                        dialogName: context.dialogName,
+                        npcName: context.npcName,
+                        details: `Set status to ${(action as any).status}`
+                     });
+                } else if (type === 'logEntry') {
+                     refs.push({
+                        type: 'entry',
+                        functionName: func.name,
+                        dialogName: context.dialogName,
+                        npcName: context.npcName,
+                        details: `Entry: "${(action as any).text}"`
+                     });
+                }
+            }
+        });
+
+        // Check conditions for MIS_ var
+        func.conditions?.forEach(cond => {
+             // Basic check for variable condition structure as serialized
+             if ('variableName' in cond && (cond as any).variableName === misVarName) {
+                 const context = funcToDialog.get(func.name) || { };
+                 refs.push({
+                    type: 'status',
+                    functionName: func.name,
+                    dialogName: context.dialogName,
+                    npcName: context.npcName,
+                    details: `Condition: ${(cond as any).negated ? '!' : ''}${misVarName}`
+                 });
+             }
+        });
+    });
+
+    return refs;
+  }, [semanticModel, questName, misVarName]);
+
+  return (
+    <Box sx={{ p: 3, height: '100%', overflow: 'auto' }}>
+      <Typography variant="h4" gutterBottom>
+        {String(questConstant?.value || questName).replace(/^"|"$/g, '')}
+      </Typography>
+
+      <Stack direction="row" spacing={1} sx={{ mb: 3 }}>
+        <Chip label={questName} variant="outlined" />
+        {misVariable ? (
+            <Chip label={`Var: ${misVarName}`} color="success" variant="outlined" />
+        ) : (
+            <Chip label={`Missing Var: ${misVarName}`} color="warning" variant="outlined" />
+        )}
+      </Stack>
+
+      <Paper sx={{ p: 2, mb: 3 }}>
+         <Typography variant="h6" gutterBottom>Log Entries & Updates</Typography>
+         <List>
+            {references.map((ref, i) => (
+                <React.Fragment key={i}>
+                    <ListItem alignItems="flex-start">
+                        <ListItemText
+                            primary={ref.details}
+                            secondary={
+                                <>
+                                    <Typography component="span" variant="body2" color="text.primary">
+                                        {ref.dialogName || ref.functionName}
+                                    </Typography>
+                                    {ref.npcName && ` (${ref.npcName})`}
+                                </>
+                            }
+                        />
+                    </ListItem>
+                    <Divider component="li" />
+                </React.Fragment>
+            ))}
+            {references.length === 0 && (
+                <ListItem><ListItemText primary="No references found" /></ListItem>
+            )}
+         </List>
+      </Paper>
+    </Box>
+  );
+};
+
+export default QuestDetails;

--- a/daedalus-dialog-editor/src/renderer/components/QuestEditor.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestEditor.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { Box } from '@mui/material';
+import QuestList from './QuestList';
+import QuestDetails from './QuestDetails';
+import type { SemanticModel } from '../types/global';
+
+interface QuestEditorProps {
+  semanticModel: SemanticModel;
+}
+
+const QuestEditor: React.FC<QuestEditorProps> = ({ semanticModel }) => {
+  const [selectedQuest, setSelectedQuest] = useState<string | null>(null);
+
+  return (
+    <Box sx={{ display: 'flex', height: '100%', width: '100%', overflow: 'hidden' }}>
+        <Box sx={{ width: 300, flexShrink: 0 }}>
+            <QuestList
+                semanticModel={semanticModel}
+                selectedQuest={selectedQuest}
+                onSelectQuest={setSelectedQuest}
+            />
+        </Box>
+        <Box sx={{ flexGrow: 1, overflow: 'hidden' }}>
+            <QuestDetails
+                semanticModel={semanticModel}
+                questName={selectedQuest}
+            />
+        </Box>
+    </Box>
+  );
+};
+
+export default QuestEditor;

--- a/daedalus-dialog-editor/src/renderer/components/QuestList.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestList.tsx
@@ -1,0 +1,123 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Box,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Typography,
+  TextField,
+  InputAdornment,
+  Divider,
+  ToggleButton,
+  ToggleButtonGroup
+} from '@mui/material';
+import { Search as SearchIcon } from '@mui/icons-material';
+import type { SemanticModel } from '../types/global';
+
+interface QuestListProps {
+  semanticModel: SemanticModel;
+  selectedQuest: string | null;
+  onSelectQuest: (questName: string) => void;
+}
+
+const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onSelectQuest }) => {
+  const [filter, setFilter] = useState('');
+  const [viewMode, setViewMode] = useState<'all' | 'active'>('all');
+
+  // Memoize the list of all TOPIC_ constants
+  const quests = useMemo(() => {
+    const constants = semanticModel.constants || {};
+    return Object.values(constants).filter(c => c.name.startsWith('TOPIC_'));
+  }, [semanticModel.constants]);
+
+  // Memoize the set of used topics to enable "Active" filtering
+  const usedTopics = useMemo(() => {
+    const used = new Set<string>();
+
+    // Check all functions for Log_* calls
+    Object.values(semanticModel.functions || {}).forEach(func => {
+      func.actions?.forEach(action => {
+        if ('topic' in action && action.topic) {
+           used.add(action.topic);
+        }
+      });
+    });
+
+    // Also check dialog information functions (if any actions are directly on dialogs, though actions are usually on functions)
+    // The parser puts actions on DialogFunction, which are linked from Dialog.
+
+    return used;
+  }, [semanticModel.functions]);
+
+  const filteredQuests = useMemo(() => {
+    return quests.filter(q => {
+      const matchesSearch = q.name.toLowerCase().includes(filter.toLowerCase()) ||
+                            String(q.value).toLowerCase().includes(filter.toLowerCase());
+
+      if (!matchesSearch) return false;
+
+      if (viewMode === 'active') {
+        return usedTopics.has(q.name);
+      }
+
+      return true;
+    });
+  }, [quests, filter, viewMode, usedTopics]);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', borderRight: 1, borderColor: 'divider' }}>
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6" gutterBottom>Quests</Typography>
+        <TextField
+          fullWidth
+          size="small"
+          placeholder="Search quests..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon color="action" />
+              </InputAdornment>
+            ),
+          }}
+          sx={{ mb: 2 }}
+        />
+        <ToggleButtonGroup
+          value={viewMode}
+          exclusive
+          onChange={(_, mode) => mode && setViewMode(mode)}
+          fullWidth
+          size="small"
+        >
+          <ToggleButton value="all">All</ToggleButton>
+          <ToggleButton value="active">Active</ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+      <Divider />
+      <List sx={{ flexGrow: 1, overflow: 'auto' }}>
+        {filteredQuests.map((quest) => (
+          <ListItem key={quest.name} disablePadding>
+            <ListItemButton
+              selected={selectedQuest === quest.name}
+              onClick={() => onSelectQuest(quest.name)}
+            >
+              <ListItemText
+                primary={String(quest.value).replace(/^"|"$/g, '')} // Strip quotes for display
+                secondary={quest.name}
+              />
+            </ListItemButton>
+          </ListItem>
+        ))}
+        {filteredQuests.length === 0 && (
+          <ListItem>
+            <ListItemText secondary="No quests found" />
+          </ListItem>
+        )}
+      </List>
+    </Box>
+  );
+};
+
+export default QuestList;

--- a/daedalus-dialog-editor/src/renderer/types/global.d.ts
+++ b/daedalus-dialog-editor/src/renderer/types/global.d.ts
@@ -30,6 +30,8 @@ export type {
   DialogProperties,
   Dialog,
   ParseError,
+  GlobalConstant,
+  GlobalVariable,
   SemanticModel,
   FunctionTreeChild,
   FunctionTreeNode,

--- a/daedalus-dialog-editor/src/shared/types.ts
+++ b/daedalus-dialog-editor/src/shared/types.ts
@@ -173,10 +173,22 @@ export interface ParseError {
   text?: string;
 }
 
+export interface GlobalConstant {
+  name: string;
+  type: string;
+  value: string | number | boolean;
+}
+
+export interface GlobalVariable {
+  name: string;
+  type: string;
+}
+
 export interface SemanticModel {
   dialogs: Record<string, Dialog>;
   functions: Record<string, DialogFunction>;
-  constants?: Record<string, unknown>;
+  constants?: Record<string, GlobalConstant>;
+  variables?: Record<string, GlobalVariable>;
   instances?: Record<string, unknown>;
   hasErrors: boolean;
   errors: ParseError[];


### PR DESCRIPTION
This PR initializes the Quest Editor UI in the Daedalus Dialog Editor. It builds upon the existing parser capabilities (which already extract global constants and variables) by exposing them in the shared types and creating a dedicated view for managing quests.

Key changes:
- **Shared Types:** Added `GlobalConstant` and `GlobalVariable` interfaces to the shared types and updated `SemanticModel` to include `constants` and `variables` maps.
- **Quest Components:**
  - `QuestList`: A sidebar list showing all detected `TOPIC_*` constants. It includes a search bar and a toggle to filter by "Active" (referenced) quests.
  - `QuestDetails`: A detail view showing the quest name (value of the constant), the associated `MIS_` variable status, and a list of all references (Log entries, status updates) found in the code.
  - `QuestEditor`: The main container combining the list and details view.
- **Navigation:** Introduced `MainLayout` which adds a sidebar with "Dialog" and "Quest" tabs, allowing the user to switch between the standard dialog tree view and the new quest editor.
- **Frontend Verification:** Validated the new UI layout using a Playwright script.

---
*PR created automatically by Jules for task [5879258639100146137](https://jules.google.com/task/5879258639100146137) started by @daniel-daga*