### PR TITLE
Implement global quest data loading for Quest Editor

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/MainLayout.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/MainLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Box, ToggleButton, ToggleButtonGroup, Paper, Tooltip } from '@mui/material';
 import { Chat as ChatIcon, Book as BookIcon } from '@mui/icons-material';
 import ThreeColumnLayout from './ThreeColumnLayout';
@@ -14,11 +14,17 @@ interface MainLayoutProps {
 const MainLayout: React.FC<MainLayoutProps> = ({ filePath }) => {
   const [view, setView] = useState<'dialog' | 'quest'>('dialog');
   const { openFiles } = useEditorStore();
-  const { projectPath, mergedSemanticModel } = useProjectStore();
+  const { projectPath, mergedSemanticModel, loadQuestData } = useProjectStore();
 
   const fileState = filePath ? openFiles.get(filePath) : null;
   const isProjectMode = !!projectPath;
   const semanticModel = isProjectMode ? mergedSemanticModel : (fileState?.semanticModel || {});
+
+  useEffect(() => {
+    if (view === 'quest' && isProjectMode) {
+      loadQuestData();
+    }
+  }, [view, isProjectMode, loadQuestData]);
 
   return (
     <Box sx={{ display: 'flex', height: '100%', width: '100%' }}>

--- a/daedalus-dialog-editor/src/shared/types.ts
+++ b/daedalus-dialog-editor/src/shared/types.ts
@@ -16,6 +16,7 @@ export interface ProjectIndex {
   npcs: string[];
   dialogsByNpc: Map<string, DialogMetadata[]>;
   allFiles: string[];
+  questFiles: string[];
 }
 
 // ============================================================================


### PR DESCRIPTION
This PR addresses the "Global Scope Gap" in the Quest Editor architecture. 

It implements the detection and loading of global constants (e.g. `TOPIC_MyQuest`) and variables (e.g. `MIS_MyQuest`) that are essential for defining quests in Gothic 2 but are often located in files separate from Dialogs.

Changes:
- Modified `ProjectService` to scan for `TOPIC_` and `MIS_` patterns during project indexing.
- Added `questFiles` to `ProjectIndex` and `ProjectStore`.
- Added `loadQuestData` action to `ProjectStore` which parses identified quest files and merges them into the semantic model.
- Updated `MainLayout` to trigger `loadQuestData` when the user switches to the Quest Editor view.
- Added tests for quest file detection in `ProjectService`.

---
*PR created automatically by Jules for task [7954472896982810574](https://jules.google.com/task/7954472896982810574) started by @daniel-daga*