### PR TITLE
Quest Editor: Implement Quest Creation Wizard

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/CreateQuestDialog.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/CreateQuestDialog.tsx
@@ -1,0 +1,189 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  FormHelperText,
+  Stack,
+  Alert
+} from '@mui/material';
+import { useProjectStore } from '../store/projectStore';
+
+interface CreateQuestDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const CreateQuestDialog: React.FC<CreateQuestDialogProps> = ({ open, onClose }) => {
+  const { mergedSemanticModel, createQuest, isLoading } = useProjectStore();
+
+  const [title, setTitle] = useState('');
+  const [internalName, setInternalName] = useState('');
+  const [topicFile, setTopicFile] = useState('');
+  const [variableFile, setVariableFile] = useState('');
+  const [isInternalNameTouched, setIsInternalNameTouched] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Analyze existing quests to find common files
+  const fileSuggestions = useMemo(() => {
+    const topicFiles = new Map<string, number>();
+    const varFiles = new Map<string, number>();
+
+    Object.values(mergedSemanticModel.constants || {}).forEach(c => {
+        if (c.name.startsWith('TOPIC_') && c.filePath) {
+            topicFiles.set(c.filePath, (topicFiles.get(c.filePath) || 0) + 1);
+        }
+    });
+
+    Object.values(mergedSemanticModel.variables || {}).forEach(v => {
+        if (v.name.startsWith('MIS_') && v.filePath) {
+            varFiles.set(v.filePath, (varFiles.get(v.filePath) || 0) + 1);
+        }
+    });
+
+    // Sort by frequency
+    const sortedTopicFiles = Array.from(topicFiles.entries())
+        .sort((a, b) => b[1] - a[1])
+        .map(e => e[0]);
+
+    const sortedVarFiles = Array.from(varFiles.entries())
+        .sort((a, b) => b[1] - a[1])
+        .map(e => e[0]);
+
+    return {
+        topics: sortedTopicFiles,
+        variables: sortedVarFiles
+    };
+  }, [mergedSemanticModel]);
+
+  // Set default files when opening
+  useEffect(() => {
+    if (open) {
+        if (fileSuggestions.topics.length > 0) setTopicFile(fileSuggestions.topics[0]);
+        if (fileSuggestions.variables.length > 0) setVariableFile(fileSuggestions.variables[0]);
+    }
+  }, [open, fileSuggestions]);
+
+  // Auto-generate internal name
+  useEffect(() => {
+    if (!isInternalNameTouched && title) {
+        // "The Lost Sheep" -> "LostSheep" (remove articles, remove spaces)
+        const generated = title
+            .replace(/^(The|A|An)\s+/i, '')
+            .replace(/[^a-zA-Z0-9]/g, '');
+        setInternalName(generated);
+    }
+  }, [title, isInternalNameTouched]);
+
+  const handleSubmit = async () => {
+    if (!title || !internalName || !topicFile || !variableFile) {
+        setError('All fields are required');
+        return;
+    }
+
+    // Check for duplicate names
+    if (mergedSemanticModel.constants?.[`TOPIC_${internalName}`]) {
+        setError(`TOPIC_${internalName} already exists`);
+        return;
+    }
+    if (mergedSemanticModel.variables?.[`MIS_${internalName}`]) {
+        setError(`MIS_${internalName} already exists`);
+        return;
+    }
+
+    try {
+        await createQuest(title, internalName, topicFile, variableFile);
+        onClose();
+        // Reset form
+        setTitle('');
+        setInternalName('');
+        setIsInternalNameTouched(false);
+        setError(null);
+    } catch (e) {
+        setError(e instanceof Error ? e.message : 'Unknown error');
+    }
+  };
+
+  const formatPath = (path: string) => {
+      // Show only filename if possible, or relative path
+      // Since we don't have project root handy here (it's in store),
+      // we'll just show the last part for now or full path.
+      const parts = path.split(/[/\\]/);
+      return parts[parts.length - 1];
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Create New Quest</DialogTitle>
+      <DialogContent>
+        <Stack spacing={3} sx={{ mt: 1 }}>
+            {error && <Alert severity="error">{error}</Alert>}
+
+            <TextField
+                label="Quest Title"
+                placeholder="e.g. The Lost Sheep"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                autoFocus
+                fullWidth
+            />
+
+            <TextField
+                label="Internal Name"
+                placeholder="e.g. LostSheep"
+                value={internalName}
+                onChange={(e) => {
+                    setInternalName(e.target.value);
+                    setIsInternalNameTouched(true);
+                }}
+                helperText={`Will create: TOPIC_${internalName || '...'} and MIS_${internalName || '...'}`}
+                fullWidth
+            />
+
+            <FormControl fullWidth>
+                <InputLabel>Quest Definition File (TOPIC_)</InputLabel>
+                <Select
+                    value={topicFile}
+                    label="Quest Definition File (TOPIC_)"
+                    onChange={(e) => setTopicFile(e.target.value)}
+                >
+                    {fileSuggestions.topics.map(f => (
+                        <MenuItem key={f} value={f}>{formatPath(f)}</MenuItem>
+                    ))}
+                </Select>
+                <FormHelperText>{topicFile}</FormHelperText>
+            </FormControl>
+
+            <FormControl fullWidth>
+                <InputLabel>Variable Definition File (MIS_)</InputLabel>
+                <Select
+                    value={variableFile}
+                    label="Variable Definition File (MIS_)"
+                    onChange={(e) => setVariableFile(e.target.value)}
+                >
+                    {fileSuggestions.variables.map(f => (
+                        <MenuItem key={f} value={f}>{formatPath(f)}</MenuItem>
+                    ))}
+                </Select>
+                <FormHelperText>{variableFile}</FormHelperText>
+            </FormControl>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={isLoading}>
+            {isLoading ? 'Creating...' : 'Create Quest'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default CreateQuestDialog;

--- a/daedalus-dialog-editor/src/renderer/components/QuestList.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestList.tsx
@@ -10,10 +10,13 @@ import {
   InputAdornment,
   Divider,
   ToggleButton,
-  ToggleButtonGroup
+  ToggleButtonGroup,
+  IconButton,
+  Tooltip
 } from '@mui/material';
-import { Search as SearchIcon } from '@mui/icons-material';
+import { Search as SearchIcon, Add as AddIcon } from '@mui/icons-material';
 import type { SemanticModel } from '../types/global';
+import CreateQuestDialog from './CreateQuestDialog';
 
 interface QuestListProps {
   semanticModel: SemanticModel;
@@ -24,6 +27,7 @@ interface QuestListProps {
 const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onSelectQuest }) => {
   const [filter, setFilter] = useState('');
   const [viewMode, setViewMode] = useState<'all' | 'active'>('all');
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
 
   // Memoize the list of all TOPIC_ constants
   const quests = useMemo(() => {
@@ -68,7 +72,14 @@ const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onS
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', borderRight: 1, borderColor: 'divider' }}>
       <Box sx={{ p: 2 }}>
-        <Typography variant="h6" gutterBottom>Quests</Typography>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+          <Typography variant="h6">Quests</Typography>
+          <Tooltip title="Create New Quest">
+            <IconButton onClick={() => setIsCreateDialogOpen(true)} size="small">
+              <AddIcon />
+            </IconButton>
+          </Tooltip>
+        </Box>
         <TextField
           fullWidth
           size="small"
@@ -116,6 +127,7 @@ const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onS
           </ListItem>
         )}
       </List>
+      <CreateQuestDialog open={isCreateDialogOpen} onClose={() => setIsCreateDialogOpen(false)} />
     </Box>
   );
 };

--- a/daedalus-dialog-editor/src/shared/types.ts
+++ b/daedalus-dialog-editor/src/shared/types.ts
@@ -178,11 +178,13 @@ export interface GlobalConstant {
   name: string;
   type: string;
   value: string | number | boolean;
+  filePath?: string;
 }
 
 export interface GlobalVariable {
   name: string;
   type: string;
+  filePath?: string;
 }
 
 export interface SemanticModel {

--- a/daedalus-parser/src/semantic/semantic-model.ts
+++ b/daedalus-parser/src/semantic/semantic-model.ts
@@ -27,6 +27,7 @@ export class GlobalConstant {
   public name: string;
   public type: string;
   public value: string | number | boolean;
+  public filePath?: string;
 
   constructor(name: string, type: string, value: string | number | boolean) {
     this.name = name;
@@ -42,6 +43,7 @@ export class GlobalConstant {
 export class GlobalVariable {
   public name: string;
   public type: string;
+  public filePath?: string;
 
   constructor(name: string, type: string) {
     this.name = name;


### PR DESCRIPTION
This PR implements the "Create New Quest" feature as outlined in the Quest Editor Architecture document.
It addresses the need to easily create new quest constants (`TOPIC_`) and variables (`MIS_`) directly from the editor.

Key changes:
1.  **daedalus-parser**: Updated `GlobalConstant` and `GlobalVariable` to include an optional `filePath` property.
2.  **ProjectStore**:
    *   Updated `getSemanticModel` to inject the source file path into the semantic model's constants and variables.
    *   Implemented `createQuest` action which appends new definitions to selected files and reloads the data.
3.  **UI**:
    *   Created `CreateQuestDialog` which asks for Quest Title, Internal Name, and Target Files.
    *   It intelligently suggests target files based on where other quests are defined.
    *   Added a "Create New Quest" button to `QuestList`.

This closes the "Gap Analysis" regarding missing global data (which was actually solved by parser updates but enhanced here with file tracking) and implements the "Create New Quest" requirement.

---
*PR created automatically by Jules for task [1873348504754532869](https://jules.google.com/task/1873348504754532869) started by @daniel-daga*