### PR TITLE
⚡ Virtualize DialogTree for performance improvement

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/ChoiceTreeItem.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/ChoiceTreeItem.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, CSSProperties } from 'react';
 import {
   Box,
   ListItemButton,
@@ -11,35 +11,39 @@ import {
   ExpandMore as ExpandMoreIcon,
   ChevronRight as ChevronRightIcon
 } from '@mui/icons-material';
+import type { FunctionTreeChild } from '../types/global';
 
 interface ChoiceTreeItemProps {
-  choice: any; // Using any as in DialogTreeItem, but ideally should be FunctionTreeChild
+  choice: FunctionTreeChild;
   depth: number;
   index: number;
-  expandedChoices: Set<string>;
+  choiceKey: string;
+  isExpanded: boolean;
+  hasChildren: boolean;
   selectedFunctionName: string | null;
-  dialogName: string; // Needed for onSelectDialog
+  dialogName: string;
   onSelectDialog: (dialogName: string, functionName: string | null) => void;
   onToggleChoiceExpand: (choiceKey: string) => void;
+  style: CSSProperties;
 }
 
 const ChoiceTreeItem = memo(({
   choice,
   depth,
   index,
-  expandedChoices,
+  choiceKey,
+  isExpanded,
+  hasChildren,
   selectedFunctionName,
   dialogName,
   onSelectDialog,
-  onToggleChoiceExpand
+  onToggleChoiceExpand,
+  style
 }: ChoiceTreeItemProps) => {
   const isChoiceSelected = selectedFunctionName === choice.targetFunction;
-  const hasSubchoices = choice.subtree && choice.subtree.children && choice.subtree.children.length > 0;
-  const choiceKey = `${choice.targetFunction}-${depth}-${index}`;
-  const isChoiceExpanded = expandedChoices.has(choiceKey);
 
   return (
-    <Box>
+    <Box style={style}>
       <ListItemButton
         selected={isChoiceSelected}
         onClick={() => {
@@ -47,8 +51,8 @@ const ChoiceTreeItem = memo(({
         }}
         sx={{ pl: (depth + 1) * 2, pr: 1 }}
       >
-        {hasSubchoices ? (
-          <Tooltip title={isChoiceExpanded ? 'Collapse' : 'Expand'}>
+        {hasChildren ? (
+          <Tooltip title={isExpanded ? 'Collapse' : 'Expand'}>
             <IconButton
               size="small"
               onClick={(e) => {
@@ -56,9 +60,9 @@ const ChoiceTreeItem = memo(({
                 onToggleChoiceExpand(choiceKey);
               }}
               sx={{ width: 28, height: 28, mr: 0.5, flexShrink: 0 }}
-              aria-label={isChoiceExpanded ? 'Collapse choice' : 'Expand choice'}
+              aria-label={isExpanded ? 'Collapse choice' : 'Expand choice'}
             >
-              {isChoiceExpanded ? <ExpandMoreIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+              {isExpanded ? <ExpandMoreIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
             </IconButton>
           </Tooltip>
         ) : (
@@ -72,51 +76,17 @@ const ChoiceTreeItem = memo(({
           secondaryTypographyProps={{ fontSize: '0.7rem' }}
         />
       </ListItemButton>
-      {isChoiceExpanded && hasSubchoices && choice.subtree.children.map((subchoice: any, idx: number) => (
-        <ChoiceTreeItem
-          key={`${subchoice.targetFunction}-${depth + 1}-${idx}`}
-          choice={subchoice}
-          depth={depth + 1}
-          index={idx}
-          expandedChoices={expandedChoices}
-          selectedFunctionName={selectedFunctionName}
-          dialogName={dialogName}
-          onSelectDialog={onSelectDialog}
-          onToggleChoiceExpand={onToggleChoiceExpand}
-        />
-      ))}
     </Box>
   );
 }, (prev, next) => {
-  // 1. Check critical props
   if (prev.choice !== next.choice) return false;
   if (prev.depth !== next.depth) return false;
-  if (prev.index !== next.index) return false;
-  if (prev.dialogName !== next.dialogName) return false;
-  if (prev.onSelectDialog !== next.onSelectDialog) return false;
-  if (prev.onToggleChoiceExpand !== next.onToggleChoiceExpand) return false;
+  if (prev.choiceKey !== next.choiceKey) return false;
+  if (prev.isExpanded !== next.isExpanded) return false;
+  if (prev.hasChildren !== next.hasChildren) return false;
   if (prev.selectedFunctionName !== next.selectedFunctionName) return false;
-
-  // 2. Check expansion state
-  const prevKey = `${prev.choice.targetFunction}-${prev.depth}-${prev.index}`;
-  const nextKey = `${next.choice.targetFunction}-${next.depth}-${next.index}`;
-
-  // Key should be stable if choice/depth/index are stable, but good to be safe
-  if (prevKey !== nextKey) return false;
-
-  const prevExpanded = prev.expandedChoices.has(prevKey);
-  const nextExpanded = next.expandedChoices.has(nextKey);
-
-  // If expansion state changed, we MUST re-render
-  if (prevExpanded !== nextExpanded) return false;
-
-  // If we are collapsed (and stayed collapsed), we can IGNORE changes to expandedChoices
-  // because they don't affect our rendering (we don't render children)
-  if (!nextExpanded) return true;
-
-  // If we are expanded, we MUST re-render to pass the new expandedChoices ref to our children
-  // so they can update their own expansion state
-  if (prev.expandedChoices !== next.expandedChoices) return false;
+  if (prev.dialogName !== next.dialogName) return false;
+  if (prev.style !== next.style) return false;
 
   return true;
 });

--- a/daedalus-dialog-editor/src/renderer/components/dialogTreeUtils.ts
+++ b/daedalus-dialog-editor/src/renderer/components/dialogTreeUtils.ts
@@ -1,0 +1,100 @@
+import { SemanticModel, FunctionTreeNode, FunctionTreeChild } from '../types/global';
+
+export type DialogRowData = {
+  type: 'dialog';
+  id: string; // dialogName
+  dialogName: string;
+  hasChildren: boolean;
+  isExpanded: boolean;
+  depth: number;
+};
+
+export type ChoiceRowData = {
+  type: 'choice';
+  id: string; // choiceKey
+  choice: FunctionTreeChild;
+  dialogName: string; // parent dialog name
+  hasChildren: boolean;
+  isExpanded: boolean;
+  depth: number;
+  index: number; // index in parent children array
+};
+
+export type FlatItem = DialogRowData | ChoiceRowData;
+
+export const flattenDialogs = (
+  filteredDialogs: string[],
+  semanticModel: SemanticModel,
+  expandedDialogs: Set<string>,
+  expandedChoices: Set<string>,
+  buildFunctionTree: (funcName: string, ancestorPath?: string[]) => FunctionTreeNode | null
+): FlatItem[] => {
+  const items: FlatItem[] = [];
+
+  for (const dialogName of filteredDialogs) {
+    const dialog = semanticModel.dialogs?.[dialogName];
+    if (!dialog) continue;
+
+    const isExpanded = expandedDialogs.has(dialogName);
+    const infoFunc = dialog.properties?.information as any;
+    const infoFuncName = typeof infoFunc === 'string' ? infoFunc : infoFunc?.name;
+    const infoFuncData = infoFuncName ? semanticModel.functions?.[infoFuncName] : null;
+
+    let tree: FunctionTreeNode | null = null;
+    let hasChildren = false;
+
+    if (isExpanded) {
+      tree = infoFuncName ? buildFunctionTree(infoFuncName) : null;
+      hasChildren = !!(tree && tree.children && tree.children.length > 0);
+    } else if (infoFuncData && infoFuncData.actions) {
+      // Shallow check
+      hasChildren = infoFuncData.actions.some((a: any) => 'dialogRef' in a && 'targetFunction' in a);
+    }
+
+    items.push({
+      type: 'dialog',
+      id: dialogName,
+      dialogName: dialogName,
+      hasChildren,
+      isExpanded,
+      depth: 0
+    });
+
+    if (isExpanded && tree && tree.children.length > 0) {
+      flattenChoices(items, tree.children, 1, dialogName, expandedChoices);
+    }
+  }
+
+  return items;
+};
+
+const flattenChoices = (
+  items: FlatItem[],
+  children: FunctionTreeChild[],
+  depth: number,
+  dialogName: string,
+  expandedChoices: Set<string>
+) => {
+  children.forEach((choice, index) => {
+    const choiceKey = `${choice.targetFunction}-${depth}-${index}`;
+
+    const isExpanded = expandedChoices.has(choiceKey);
+    // Note: subtree is populated by buildFunctionTree recursively
+    const hasSubchoices = !!(choice.subtree && choice.subtree.children && choice.subtree.children.length > 0);
+
+    items.push({
+      type: 'choice',
+      id: choiceKey,
+      choice,
+      dialogName,
+      hasChildren: hasSubchoices,
+      isExpanded,
+      depth,
+      index
+    });
+
+    if (isExpanded && hasSubchoices && choice.subtree) {
+      flattenChoices(items, choice.subtree.children, depth + 1, dialogName, expandedChoices);
+    }
+  });
+};

--- a/daedalus-dialog-editor/tests/DialogTreeItem.perf.test.tsx
+++ b/daedalus-dialog-editor/tests/DialogTreeItem.perf.test.tsx
@@ -3,42 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import DialogTreeItem from '../src/renderer/components/DialogTreeItem';
 
-// Mock the recursive buildFunctionTree
-const mockBuildFunctionTree = (funcName, ancestorPath = []) => {
-  if (funcName === 'Info_Dialog') {
-    return {
-      name: 'Info_Dialog',
-      children: [
-        {
-          text: 'Choice 1',
-          targetFunction: 'Choice_1',
-          subtree: {
-            name: 'Choice_1',
-            children: [
-              {
-                text: 'Choice 1.1',
-                targetFunction: 'Choice_1_1',
-                subtree: { name: 'Choice_1_1', children: [] }
-              }
-            ]
-          }
-        },
-        {
-          text: 'Choice 2',
-          targetFunction: 'Choice_2',
-          subtree: { name: 'Choice_2', children: [] }
-        },
-        {
-          text: 'Choice 3',
-          targetFunction: 'Choice_3',
-          subtree: { name: 'Choice_3', children: [] }
-        }
-      ]
-    };
-  }
-  return null;
-};
-
+// Mock semantic model
 const mockSemanticModel = {
   dialogs: {
     'DIA_Test': {
@@ -62,17 +27,13 @@ describe('DialogTreeItem Performance', () => {
       semanticModel: mockSemanticModel,
       isSelected: false,
       isExpanded: true,
-      expandedChoices: new Set(),
-      selectedFunctionName: null,
       onSelectDialog: jest.fn(),
       onToggleDialogExpand: jest.fn(),
-      onToggleChoiceExpand: jest.fn(),
-      buildFunctionTree: mockBuildFunctionTree
+      hasChildren: true,
+      style: { height: 40, width: '100%' }
     };
 
     render(<DialogTreeItem {...props} />);
     expect(screen.getByText('Test Dialog')).toBeInTheDocument();
-    expect(screen.getByText('Choice 1')).toBeInTheDocument();
-    expect(screen.getByText('Choice 2')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Implemented list virtualization for the `DialogTree` component using `react-window` and `react-virtualized-auto-sizer`. 
- Created `flattenDialogs` utility to flatten the hierarchical dialog/choice structure into a linear list.
- Refactored `DialogTreeItem` and `ChoiceTreeItem` to remove recursive rendering and act as efficient row renderers.
- Updated `DialogTree` to use `FixedSizeList` with `AutoSizer`.
- This change significantly improves rendering performance for NPCs with many dialogs by rendering only visible items.

---
*PR created automatically by Jules for task [1020537425161511446](https://jules.google.com/task/1020537425161511446) started by @daniel-daga*