### PR TITLE
Add GitHub Action workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run tests
+      run: npm test


### PR DESCRIPTION
Added a GitHub Action workflow to run tests on push and PR to main. The workflow installs dependencies and runs `npm test` which covers both `daedalus-parser` and `daedalus-dialog-editor` workspaces.

---
*PR created automatically by Jules for task [1057856729149340850](https://jules.google.com/task/1057856729149340850) started by @daniel-daga*