### PR TITLE
Consolidate npm tasks and separate dev/prod jobs

### DIFF
--- a/daedalus-dialog-editor/package.json
+++ b/daedalus-dialog-editor/package.json
@@ -4,7 +4,7 @@
   "description": "Visual dialog editor for Gothic 2 Daedalus scripting language",
   "main": "dist/main/main.js",
   "scripts": {
-    "start": "electron .",
+    "preview": "electron .",
     "dev": "npm run build  && node scripts/dev.js",
     "dev:main": "tsc -p tsconfig.main.json --watch",
     "dev:renderer": "vite",
@@ -13,6 +13,7 @@
     "build": "npm run build:main && npm run build:renderer",
     "build:main": "tsc -p tsconfig.main.json",
     "build:renderer": "vite build",
+    "typecheck": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.json --noEmit",
     "package": "electron-builder",
     "test": "jest",
     "test:mocked": "jest --config jest.mocked.config.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,12 @@
     "daedalus-parser"
   ],
   "scripts": {
+    "dev": "npm run dev -w daedalus-dialog-editor",
     "build": "npm run build --workspaces",
-    "test": "npm run test --workspaces"
+    "test": "npm run test --workspaces",
+    "lint": "npm run lint --workspaces --if-present",
+    "typecheck": "npm run typecheck --workspaces --if-present",
+    "package": "npm run package -w daedalus-dialog-editor",
+    "preview": "npm run preview -w daedalus-dialog-editor"
   }
 }


### PR DESCRIPTION
This change consolidates the npm scripts across the monorepo. It renames the `start` script in `daedalus-dialog-editor` to `preview` to better reflect that it runs the built application, while `dev` is used for development. It also adds a `typecheck` script to the editor package. In the root `package.json`, it exposes common tasks like `dev`, `preview`, `package` (targeting the editor), and ensures `lint` and `typecheck` run for all workspaces. This improves developer experience by providing consistent and accessible commands from the root.

---
*PR created automatically by Jules for task [6657697469847932615](https://jules.google.com/task/6657697469847932615) started by @daniel-daga*