### PR TITLE
Quest Editor Global Analysis & Flow Visualization

### DIFF
--- a/daedalus-dialog-editor/src/renderer/store/projectStore.ts
+++ b/daedalus-dialog-editor/src/renderer/store/projectStore.ts
@@ -87,6 +87,9 @@ interface ProjectActions {
   // Load and merge quest data (global constants/vars)
   loadQuestData: () => Promise<void>;
 
+  // Get usage data for a specific quest across the entire project
+  getQuestUsage: (questName: string) => SemanticModel;
+
   // Create a new quest
   createQuest: (title: string, internalName: string, topicFilePath: string, variableFilePath: string) => Promise<void>;
 
@@ -374,77 +377,93 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   },
 
   loadQuestData: async () => {
-    const { questFiles, getSemanticModel, mergeSemanticModels, mergedSemanticModel } = get();
+    const { questFiles, getSemanticModel, mergeSemanticModels } = get();
 
     // Parse all quest files
     const models = await Promise.all(
         questFiles.map(filePath => getSemanticModel(filePath))
     );
 
-    // If we already have a merged model, we should merge into it, not replace it
-    // But mergeSemanticModels replaces it.
-    // So we should take the current merged model and merge the new ones into it?
-    // Actually, mergeSemanticModels takes an array of models and creates a NEW merged model.
-    // So if we only pass quest models, we lose the previously loaded NPC models.
-
-    // Better approach: Since `mergedSemanticModel` is currently "current NPC view",
-    // maybe we should just append the quest data to it?
-    // OR, we assume that when looking at Quests, we want a global view.
-
-    // If we are in Quest Mode, we might want to load EVERYTHING related to quests.
-    // That includes quest definitions (LOG_Constants) AND functions that use them (which might be in dialog files).
-    // This is tricky. Dialog files are loaded by NPC selection.
-
-    // Ideally, for the Quest Editor, we want a "Global Project Model" which is distinct from "Current NPC Model".
-    // But for now, let's just merge quest files into the current merged model.
-    // However, if we switch NPCs, `loadAndMergeNpcModels` will be called and overwrite `mergedSemanticModel`.
-    // So we need to ensure quest data persists or is re-merged.
-
-    // Since `mergedSemanticModel` is transient based on selection, maybe we should keep `questModels` separate?
-    // For simplicity, let's merge into `mergedSemanticModel` but we need to be careful about overwriting.
-
-    // A simple hack: Pass current merged model as one of the models to merge?
-    // No, `mergedSemanticModel` is a result, not a source with source file tracking.
-
-    // Let's rely on `loadAndMergeNpcModels` to be called when NPC is selected.
-    // When Quest View is active, we might not have an NPC selected.
-    // If we just want to show the list of quests, we need quest files parsed.
-
-    // Let's update mergeSemanticModels to NOT clear everything if we don't want to?
-    // No, `mergeSemanticModels` creates a fresh object.
-
-    // For now, let's just load the quest files and merge them.
-    // If the user selects an NPC later, it will overwrite.
-    // This implies Quest Editor should probably trigger this load every time it's focused,
-    // OR we should maintain a `globalQuestModel` in the store.
-
-    // But let's stick to the plan: merge into mergedSemanticModel.
-    // If an NPC is selected, we might lose this data unless we also merge it there.
-    // We can modify `loadAndMergeNpcModels` to also include quest files?
-    // That seems safer.
-
-    // But `loadQuestData` is explicit.
-    // Let's make `loadQuestData` merge quest files with whatever is currently in `mergedSemanticModel`?
-    // The `mergeSemanticModels` function takes `SemanticModel[]`.
-    // We can't easily decompose `mergedSemanticModel` back to its sources.
-
-    // Re-architecture choice:
-    // 1. Always load quest files when loading NPC models.
-    // 2. OR `mergedSemanticModel` accumulates.
-
-    // Let's go with 1. It ensures consistency.
-    // But `loadAndMergeNpcModels` is for *Npc*.
-
-    // Let's make `loadQuestData` explicit. When called, it merges quest files.
-    // But what about the existing data?
-    // We can merge [currentMergedModel, ...questModels].
-
-    // Check `mergeSemanticModels` implementation again.
-    // It creates a NEW empty model and merges into it.
-    // So passing `mergedSemanticModel` as one of the inputs works!
-
     const currentModel = get().mergedSemanticModel;
     mergeSemanticModels([currentModel, ...models]);
+  },
+
+  getQuestUsage: (questName: string) => {
+    const { parsedFiles } = get();
+    const result = createEmptySemanticModel();
+    const misVarName = questName.replace('TOPIC_', 'MIS_');
+    const relevantFunctionNames = new Set<string>();
+
+    // Pass 1: Identify all relevant functions and add definitions
+    for (const fileData of parsedFiles.values()) {
+        const model = fileData.semanticModel;
+
+        // Constants & Variables
+        if (model.constants && model.constants[questName]) {
+             result.constants = result.constants || {};
+             result.constants[questName] = model.constants[questName];
+        }
+        if (model.variables && model.variables[misVarName]) {
+             result.variables = result.variables || {};
+             result.variables[misVarName] = model.variables[misVarName];
+        }
+
+        // Functions
+        if (model.functions) {
+             Object.values(model.functions).forEach(func => {
+                 let isRelevant = false;
+
+                 // Check Actions
+                 if (func.actions) {
+                     for (const action of func.actions) {
+                         // Check for TOPIC usage
+                         if ('topic' in action && action.topic === questName) {
+                             isRelevant = true;
+                             break;
+                         }
+                     }
+                 }
+
+                 // Check Conditions
+                 if (!isRelevant && func.conditions) {
+                     for (const cond of func.conditions) {
+                         // Check for MIS variable usage
+                         if ('variableName' in cond && cond.variableName === misVarName) {
+                             isRelevant = true;
+                             break;
+                         }
+                     }
+                 }
+
+                 if (isRelevant) {
+                     relevantFunctionNames.add(func.name);
+                     result.functions[func.name] = func;
+                 }
+             });
+        }
+    }
+
+    // Pass 2: Identify Dialogs that use relevant functions
+    for (const fileData of parsedFiles.values()) {
+        const model = fileData.semanticModel;
+
+        if (model.dialogs) {
+            Object.values(model.dialogs).forEach(dialog => {
+                const info = dialog.properties.information;
+                const cond = dialog.properties.condition;
+
+                const infoName = typeof info === 'string' ? info : (typeof info === 'object' ? info.name : null);
+                const condName = typeof cond === 'string' ? cond : (typeof cond === 'object' ? cond.name : null);
+
+                if ((infoName && relevantFunctionNames.has(infoName)) ||
+                    (condName && relevantFunctionNames.has(condName))) {
+                    result.dialogs[dialog.name] = dialog;
+                }
+            });
+        }
+    }
+
+    return result;
   },
 
   createQuest: async (title: string, internalName: string, topicFilePath: string, variableFilePath: string) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,13 @@
       "workspaces": [
         "daedalus-dialog-editor",
         "daedalus-parser"
-      ]
+      ],
+      "dependencies": {
+        "@rollup/rollup-linux-x64-gnu": "*"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.57.1"
+      }
     },
     "daedalus-dialog-editor": {
       "version": "0.1.0",
@@ -2435,6 +2441,19 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.57.1",


### PR DESCRIPTION
This PR significantly improves the Quest Editor by enabling it to see the "big picture" of a quest across the entire project.

Key changes:
1.  **Global Quest Analysis**: Previously, the editor only saw references in the currently open file or selected NPC. The new `getQuestUsage` function in `projectStore` scans all ingested files to find every dialog and function that touches a specific quest (via `TOPIC_` constant or `MIS_` variable).
2.  **Visual Quest Flow**: The `QuestFlow` component has been completely rewritten. It now uses a "Swimlane" layout (grouped by NPC) and topological sorting to visualize the quest progression. Nodes are color-coded by type (Start, Update, Success, Fail), and edges explicitly show the conditions (e.g., `MIS_MyQuest == 1` or `Knows Info`).
3.  **Loading State**: Added a UI indicator to inform the user when the project is still being scanned/ingested, as incomplete data might result in a partial graph.
4.  **Testing**: Added a unit test suite to verify the multi-file aggregation logic.

---
*PR created automatically by Jules for task [14524254900373698782](https://jules.google.com/task/14524254900373698782) started by @daniel-daga*