### PR TITLE
⚡ Bolt: Optimize NPCList re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-02-01 - Monolithic State vs React Memoization
 **Learning:** The `semanticModel` object is a large monolithic state that is recreated on every edit. Passing this entire object to list items like `DialogTreeItem` defeats `React.memo` unless a custom comparator is used to check only relevant sub-properties. Furthermore, callbacks like `buildFunctionTree` that depend on the entire model will break memoization of child components.
 **Action:** When working with `semanticModel`, extract stable sub-properties (like `functions` map) for dependencies, and use granular checks in `React.memo` comparators to avoid O(N) re-renders on single-item updates.
+
+## 2026-02-04 - Testing React.memo with Mocks
+**Learning:** When testing `React.memo` components that consume hooks (like `useSearchStore`), simple mock functions returning values won't trigger re-renders when "state" changes in the test. You must force a re-render (e.g., by changing a prop) to verify the component updates its view based on the new hook value.
+**Action:** When testing memoized components with mocked hooks, ensure the test explicitly triggers a re-render or the mock implements a subscription mechanism.

--- a/daedalus-dialog-editor/src/renderer/components/NPCList.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/NPCList.tsx
@@ -127,4 +127,4 @@ const NPCList: React.FC<NPCListProps> = ({ npcs, npcMap, selectedNPC, onSelectNP
   );
 };
 
-export default NPCList;
+export default React.memo(NPCList);

--- a/daedalus-dialog-editor/src/renderer/components/ThreeColumnLayout.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/ThreeColumnLayout.tsx
@@ -267,7 +267,7 @@ const ThreeColumnLayout: React.FC<ThreeColumnLayoutProps> = ({ filePath }) => {
   const currentFunctionName = selectedFunctionName || dialogInfoFunctionName;
   const currentFunctionData = currentFunctionName ? semanticModel.functions?.[currentFunctionName] : null;
 
-  const handleSelectNPC = async (npc: string) => {
+  const handleSelectNPC = useCallback(async (npc: string) => {
     setSelectedDialog(null);
 
     // In project mode, load semantic models for this NPC's dialogs
@@ -293,7 +293,7 @@ const ThreeColumnLayout: React.FC<ThreeColumnLayoutProps> = ({ filePath }) => {
       // Single-file mode: just set the selected NPC
       setSelectedNPC(npc);
     }
-  };
+  }, [isProjectMode, selectNpc, dialogIndex, getSemanticModel, loadAndMergeNpcModels]);
 
   const handleSelectDialog = useCallback((dialogName: string, functionName: string | null) => {
     // Cancel any pending RAF callbacks from previous dialog selection (Bug #1 fix)

--- a/daedalus-dialog-editor/tests/NPCList.re-render.test.tsx
+++ b/daedalus-dialog-editor/tests/NPCList.re-render.test.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useCallback } from 'react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import NPCList from '../src/renderer/components/NPCList';
+import '@testing-library/jest-dom';
+
+// Mock useSearchStore
+jest.mock('../src/renderer/store/searchStore', () => {
+    let filter = '';
+    return {
+        useSearchStore: jest.fn(() => ({
+            npcFilter: filter,
+            setNpcFilter: (f: string) => { filter = f; },
+            filterNpcs: (npcs: string[]) => npcs.filter(n => n.toLowerCase().includes(filter.toLowerCase())),
+        })),
+    };
+});
+
+// Mock react-virtualized-auto-sizer
+jest.mock('react-virtualized-auto-sizer', () => ({
+  __esModule: true,
+  default: ({ children }: any) => children({ height: 500, width: 250 }),
+}));
+
+// Spy on FixedSizeList
+const fixedSizeListRenderSpy = jest.fn();
+
+jest.mock('react-window', () => ({
+  FixedSizeList: (props: any) => {
+    fixedSizeListRenderSpy(props);
+    return <div data-testid="fixed-size-list">{props.children({ index: 0, style: {}, data: props.itemData })}</div>;
+  },
+}));
+
+describe('NPCList Re-render', () => {
+    beforeEach(() => {
+        fixedSizeListRenderSpy.mockClear();
+    });
+
+    test('does NOT re-render when parent updates if memoized and props are stable', async () => {
+        const Wrapper = () => {
+            const [count, setCount] = useState(0);
+            const npcs = React.useMemo(() => ['NPC_1', 'NPC_2'], []);
+            const npcMap = React.useMemo(() => new Map([['NPC_1', ['Dialog1']]]), []);
+            const onSelectNPC = useCallback((npc: string) => {}, []); // Stable reference
+
+            return (
+                <div>
+                    <button onClick={() => setCount(c => c + 1)}>Increment</button>
+                    <NPCList
+                        npcs={npcs}
+                        npcMap={npcMap}
+                        selectedNPC={null}
+                        onSelectNPC={onSelectNPC}
+                    />
+                </div>
+            );
+        };
+
+        render(<Wrapper />);
+
+        // Initial render
+        expect(fixedSizeListRenderSpy).toHaveBeenCalledTimes(1);
+
+        // Trigger update
+        const button = screen.getByText('Increment');
+        await act(async () => {
+            fireEvent.click(button);
+        });
+
+        // Should NOT re-render because NPCList is memoized and props are stable
+        expect(fixedSizeListRenderSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/daedalus-dialog-editor/tests/NPCList.test.tsx
+++ b/daedalus-dialog-editor/tests/NPCList.test.tsx
@@ -93,9 +93,14 @@ describe('NPCList', () => {
 
     // Simulate the state update
     mockNpcFilter = '';
+
+    // In a real application, the store update would trigger a re-render.
+    // Since we are mocking the store with a simple function that doesn't trigger updates,
+    // we need to force a re-render by changing props (passing a new array reference)
+    // to ensure the component picks up the new mock value through React.memo.
     rerender(
        <NPCList
-        npcs={mockNpcs}
+        npcs={[...mockNpcs]}
         npcMap={mockNpcMap}
         selectedNPC={null}
         onSelectNPC={mockOnSelectNPC}


### PR DESCRIPTION
💡 What: Wrapped NPCList in React.memo and memoized handleSelectNPC in ThreeColumnLayout.
🎯 Why: NPCList was re-rendering on every keystroke in the editor because the parent component (ThreeColumnLayout) re-renders on semantic model updates, and handleSelectNPC was unstable.
📊 Impact: Reduces NPCList re-renders to near zero during typing.
🔬 Measurement: Verified with new regression test daedalus-dialog-editor/tests/NPCList.re-render.test.tsx

---
*PR created automatically by Jules for task [965493415865105441](https://jules.google.com/task/965493415865105441) started by @daniel-daga*