### PR TITLE
Add Variable Autocomplete to Dialog Editor

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/ConditionCard.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/ConditionCard.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useRef, useCallback } from 'react';
 import { Box, TextField, IconButton, Tooltip, Chip, Typography, Switch, FormControlLabel } from '@mui/material';
 import { Delete as DeleteIcon, Info as InfoIcon, Code as CodeIcon, Check as CheckIcon } from '@mui/icons-material';
+import VariableAutocomplete from './common/VariableAutocomplete';
+import type { SemanticModel } from '../../shared/types';
 
 interface ConditionCardProps {
   condition: any;
@@ -9,7 +11,7 @@ interface ConditionCardProps {
   updateCondition: (index: number, updated: any) => void;
   deleteCondition: (index: number) => void;
   focusCondition: (index: number) => void;
-  semanticModel?: any;
+  semanticModel?: SemanticModel;
 }
 
 const ConditionCard = React.memo(React.forwardRef<HTMLInputElement, ConditionCardProps>(({
@@ -18,7 +20,7 @@ const ConditionCard = React.memo(React.forwardRef<HTMLInputElement, ConditionCar
   totalConditions,
   updateCondition,
   deleteCondition,
-  focusCondition,
+  focusCondition: _focusCondition,
   semanticModel
 }, ref) => {
   const mainFieldRef = useRef<HTMLInputElement>(null);
@@ -118,25 +120,30 @@ const ConditionCard = React.memo(React.forwardRef<HTMLInputElement, ConditionCar
       case 'NpcKnowsInfoCondition':
         return (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1 }}>
-            <TextField
+            <VariableAutocomplete
               label="NPC"
               value={localCondition.npc || ''}
-              onChange={(e) => handleUpdate({ ...localCondition, npc: e.target.value })}
-              onBlur={flushUpdate}
-              size="small"
-              inputRef={mainFieldRef}
+              onChange={(value) => handleUpdate({ ...localCondition, npc: value })}
+              onFlush={flushUpdate}
+              showInstances
+              typeFilter="C_NPC"
+              isMainField
+              mainFieldRef={mainFieldRef}
               sx={{ flex: '1 1 30%', minWidth: 120 }}
+              semanticModel={semanticModel}
             />
             <Typography sx={{ color: 'text.secondary', fontSize: '0.875rem', flexShrink: 0 }}>
               knows
             </Typography>
-            <TextField
+            <VariableAutocomplete
               label="Dialog"
               value={localCondition.dialogRef || ''}
-              onChange={(e) => handleUpdate({ ...localCondition, dialogRef: e.target.value })}
-              onBlur={flushUpdate}
-              size="small"
+              onChange={(value) => handleUpdate({ ...localCondition, dialogRef: value })}
+              onFlush={flushUpdate}
+              showInstances
+              typeFilter="C_INFO"
               sx={{ flex: '1 1 60%', minWidth: 150 }}
+              semanticModel={semanticModel}
             />
           </Box>
         );
@@ -159,15 +166,17 @@ const ConditionCard = React.memo(React.forwardRef<HTMLInputElement, ConditionCar
               label="NOT"
               sx={{ mr: 1 }}
             />
-            <TextField
+            <VariableAutocomplete
               label="Variable Name"
               value={localCondition.variableName || ''}
-              onChange={(e) => handleUpdate({ ...localCondition, variableName: e.target.value })}
-              onBlur={flushUpdate}
-              size="small"
-              inputRef={mainFieldRef}
+              onChange={(value) => handleUpdate({ ...localCondition, variableName: value })}
+              onFlush={flushUpdate}
+              typeFilter="int"
+              isMainField
+              mainFieldRef={mainFieldRef}
               sx={{ flex: 1 }}
               placeholder="e.g., MIS_QuestCompleted"
+              semanticModel={semanticModel}
             />
           </Box>
         );

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/AttackActionRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/AttackActionRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { BaseActionRendererProps } from './types';
 import { ActionFieldContainer, ActionTextField, ActionDeleteButton } from '../common';
+import VariableAutocomplete from '../common/VariableAutocomplete';
 
 const AttackActionRenderer: React.FC<BaseActionRendererProps> = ({
   action,
@@ -8,11 +9,12 @@ const AttackActionRenderer: React.FC<BaseActionRendererProps> = ({
   handleDelete,
   flushUpdate,
   handleKeyDown,
-  mainFieldRef
+  mainFieldRef,
+  semanticModel
 }) => {
   return (
     <ActionFieldContainer>
-      <ActionTextField
+      <VariableAutocomplete
         label="Attacker"
         value={action.attacker || ''}
         onChange={(value) => handleUpdate({ ...action, attacker: value })}
@@ -21,14 +23,20 @@ const AttackActionRenderer: React.FC<BaseActionRendererProps> = ({
         isMainField
         mainFieldRef={mainFieldRef}
         sx={{ width: 90 }}
+        showInstances
+        typeFilter="C_NPC"
+        semanticModel={semanticModel}
       />
-      <ActionTextField
+      <VariableAutocomplete
         label="Target"
         value={action.target || ''}
         onChange={(value) => handleUpdate({ ...action, target: value })}
         onFlush={flushUpdate}
         onKeyDown={handleKeyDown}
         sx={{ width: 80 }}
+        showInstances
+        typeFilter="C_NPC"
+        semanticModel={semanticModel}
       />
       <ActionTextField
         label="Reason"

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/CreateInventoryItemsRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/CreateInventoryItemsRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { BaseActionRendererProps } from './types';
 import { ActionFieldContainer, ActionTextField, ActionDeleteButton } from '../common';
+import VariableAutocomplete from '../common/VariableAutocomplete';
 
 const CreateInventoryItemsRenderer: React.FC<BaseActionRendererProps> = ({
   action,
@@ -8,11 +9,12 @@ const CreateInventoryItemsRenderer: React.FC<BaseActionRendererProps> = ({
   handleDelete,
   flushUpdate,
   handleKeyDown,
-  mainFieldRef
+  mainFieldRef,
+  semanticModel
 }) => {
   return (
     <ActionFieldContainer>
-      <ActionTextField
+      <VariableAutocomplete
         label="Target"
         value={action.target || ''}
         onChange={(value) => handleUpdate({ ...action, target: value })}
@@ -21,14 +23,20 @@ const CreateInventoryItemsRenderer: React.FC<BaseActionRendererProps> = ({
         isMainField
         mainFieldRef={mainFieldRef}
         sx={{ width: 100 }}
+        showInstances
+        typeFilter="C_NPC"
+        semanticModel={semanticModel}
       />
-      <ActionTextField
+      <VariableAutocomplete
         label="Item"
         value={action.item || ''}
         onChange={(value) => handleUpdate({ ...action, item: value })}
         onFlush={flushUpdate}
         onKeyDown={handleKeyDown}
         sx={{ flex: 1 }}
+        showInstances
+        typeFilter="C_ITEM"
+        semanticModel={semanticModel}
       />
       <ActionTextField
         label="Quantity"

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/CreateTopicRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/CreateTopicRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { BaseActionRendererProps } from './types';
-import { ActionFieldContainer, ActionTextField, ActionDeleteButton } from '../common';
+import { ActionFieldContainer, ActionDeleteButton } from '../common';
+import VariableAutocomplete from '../common/VariableAutocomplete';
 
 const CreateTopicRenderer: React.FC<BaseActionRendererProps> = ({
   action,
@@ -8,11 +9,12 @@ const CreateTopicRenderer: React.FC<BaseActionRendererProps> = ({
   handleDelete,
   flushUpdate,
   handleKeyDown,
-  mainFieldRef
+  mainFieldRef,
+  semanticModel
 }) => {
   return (
     <ActionFieldContainer>
-      <ActionTextField
+      <VariableAutocomplete
         label="Topic"
         value={action.topic || ''}
         onChange={(value) => handleUpdate({ ...action, topic: value })}
@@ -21,14 +23,18 @@ const CreateTopicRenderer: React.FC<BaseActionRendererProps> = ({
         isMainField
         mainFieldRef={mainFieldRef}
         sx={{ minWidth: 180 }}
+        typeFilter="string"
+        semanticModel={semanticModel}
       />
-      <ActionTextField
+      <VariableAutocomplete
         fullWidth
         label="Topic Type"
         value={action.topicType || ''}
         onChange={(value) => handleUpdate({ ...action, topicType: value })}
         onFlush={flushUpdate}
         onKeyDown={handleKeyDown}
+        typeFilter="int"
+        semanticModel={semanticModel}
       />
       <ActionDeleteButton onClick={handleDelete} />
     </ActionFieldContainer>

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/ExchangeRoutineRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/ExchangeRoutineRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { BaseActionRendererProps } from './types';
 import { ActionFieldContainer, ActionTextField, ActionDeleteButton } from '../common';
+import VariableAutocomplete from '../common/VariableAutocomplete';
 
 const ExchangeRoutineRenderer: React.FC<BaseActionRendererProps> = ({
   action,
@@ -8,11 +9,12 @@ const ExchangeRoutineRenderer: React.FC<BaseActionRendererProps> = ({
   handleDelete,
   flushUpdate,
   handleKeyDown,
-  mainFieldRef
+  mainFieldRef,
+  semanticModel
 }) => {
   return (
     <ActionFieldContainer>
-      <ActionTextField
+      <VariableAutocomplete
         label="Target NPC"
         value={action.target || action.npc || ''}
         onChange={(value) => {
@@ -31,6 +33,9 @@ const ExchangeRoutineRenderer: React.FC<BaseActionRendererProps> = ({
         isMainField
         mainFieldRef={mainFieldRef}
         sx={{ width: 120 }}
+        showInstances
+        typeFilter="C_NPC"
+        semanticModel={semanticModel}
       />
       <ActionTextField
         fullWidth

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/GiveInventoryItemsRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/GiveInventoryItemsRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { BaseActionRendererProps } from './types';
 import { ActionFieldContainer, ActionTextField, ActionDeleteButton } from '../common';
+import VariableAutocomplete from '../common/VariableAutocomplete';
 
 const GiveInventoryItemsRenderer: React.FC<BaseActionRendererProps> = ({
   action,
@@ -8,11 +9,12 @@ const GiveInventoryItemsRenderer: React.FC<BaseActionRendererProps> = ({
   handleDelete,
   flushUpdate,
   handleKeyDown,
-  mainFieldRef
+  mainFieldRef,
+  semanticModel
 }) => {
   return (
     <ActionFieldContainer>
-      <ActionTextField
+      <VariableAutocomplete
         label="Giver"
         value={action.giver || ''}
         onChange={(value) => handleUpdate({ ...action, giver: value })}
@@ -21,22 +23,31 @@ const GiveInventoryItemsRenderer: React.FC<BaseActionRendererProps> = ({
         isMainField
         mainFieldRef={mainFieldRef}
         sx={{ width: 80 }}
+        showInstances
+        typeFilter="C_NPC"
+        semanticModel={semanticModel}
       />
-      <ActionTextField
+      <VariableAutocomplete
         label="Receiver"
         value={action.receiver || ''}
         onChange={(value) => handleUpdate({ ...action, receiver: value })}
         onFlush={flushUpdate}
         onKeyDown={handleKeyDown}
         sx={{ width: 90 }}
+        showInstances
+        typeFilter="C_NPC"
+        semanticModel={semanticModel}
       />
-      <ActionTextField
+      <VariableAutocomplete
         label="Item"
         value={action.item || ''}
         onChange={(value) => handleUpdate({ ...action, item: value })}
         onFlush={flushUpdate}
         onKeyDown={handleKeyDown}
         sx={{ flex: 1 }}
+        showInstances
+        typeFilter="C_ITEM"
+        semanticModel={semanticModel}
       />
       <ActionTextField
         label="Quantity"

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/LogEntryRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/LogEntryRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { BaseActionRendererProps } from './types';
 import { ActionFieldContainer, ActionTextField, ActionDeleteButton } from '../common';
+import VariableAutocomplete from '../common/VariableAutocomplete';
 
 const LogEntryRenderer: React.FC<BaseActionRendererProps> = ({
   action,
@@ -8,17 +9,20 @@ const LogEntryRenderer: React.FC<BaseActionRendererProps> = ({
   handleDelete,
   flushUpdate,
   handleKeyDown,
-  mainFieldRef
+  mainFieldRef,
+  semanticModel
 }) => {
   return (
     <ActionFieldContainer>
-      <ActionTextField
+      <VariableAutocomplete
         label="Topic"
         value={action.topic || ''}
         onChange={(value) => handleUpdate({ ...action, topic: value })}
         onFlush={flushUpdate}
         onKeyDown={handleKeyDown}
         sx={{ minWidth: 180 }}
+        typeFilter="string"
+        semanticModel={semanticModel}
       />
       <ActionTextField
         fullWidth

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/LogSetTopicStatusRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/LogSetTopicStatusRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { BaseActionRendererProps } from './types';
-import { ActionFieldContainer, ActionTextField, ActionDeleteButton } from '../common';
+import { ActionFieldContainer, ActionDeleteButton } from '../common';
+import VariableAutocomplete from '../common/VariableAutocomplete';
 
 const LogSetTopicStatusRenderer: React.FC<BaseActionRendererProps> = ({
   action,
@@ -8,11 +9,12 @@ const LogSetTopicStatusRenderer: React.FC<BaseActionRendererProps> = ({
   handleDelete,
   flushUpdate,
   handleKeyDown,
-  mainFieldRef
+  mainFieldRef,
+  semanticModel
 }) => {
   return (
     <ActionFieldContainer>
-      <ActionTextField
+      <VariableAutocomplete
         label="Topic"
         value={action.topic || ''}
         onChange={(value) => handleUpdate({ ...action, topic: value })}
@@ -21,14 +23,18 @@ const LogSetTopicStatusRenderer: React.FC<BaseActionRendererProps> = ({
         isMainField
         mainFieldRef={mainFieldRef}
         sx={{ minWidth: 180 }}
+        typeFilter="string"
+        semanticModel={semanticModel}
       />
-      <ActionTextField
+      <VariableAutocomplete
         fullWidth
         label="Status"
         value={action.status || ''}
         onChange={(value) => handleUpdate({ ...action, status: value })}
         onFlush={flushUpdate}
         onKeyDown={handleKeyDown}
+        typeFilter="int"
+        semanticModel={semanticModel}
       />
       <ActionDeleteButton onClick={handleDelete} />
     </ActionFieldContainer>

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/SetAttitudeActionRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/SetAttitudeActionRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { BaseActionRendererProps } from './types';
-import { ActionFieldContainer, ActionTextField, ActionDeleteButton } from '../common';
+import { ActionFieldContainer, ActionDeleteButton } from '../common';
+import VariableAutocomplete from '../common/VariableAutocomplete';
 
 const SetAttitudeActionRenderer: React.FC<BaseActionRendererProps> = ({
   action,
@@ -8,11 +9,12 @@ const SetAttitudeActionRenderer: React.FC<BaseActionRendererProps> = ({
   handleDelete,
   flushUpdate,
   handleKeyDown,
-  mainFieldRef
+  mainFieldRef,
+  semanticModel
 }) => {
   return (
     <ActionFieldContainer>
-      <ActionTextField
+      <VariableAutocomplete
         label="Target"
         value={action.target || ''}
         onChange={(value) => handleUpdate({ ...action, target: value })}
@@ -21,14 +23,19 @@ const SetAttitudeActionRenderer: React.FC<BaseActionRendererProps> = ({
         isMainField
         mainFieldRef={mainFieldRef}
         sx={{ width: 120 }}
+        showInstances
+        typeFilter="C_NPC"
+        semanticModel={semanticModel}
       />
-      <ActionTextField
+      <VariableAutocomplete
         fullWidth
         label="Attitude"
         value={action.attitude || ''}
         onChange={(value) => handleUpdate({ ...action, attitude: value })}
         onFlush={flushUpdate}
         onKeyDown={handleKeyDown}
+        typeFilter="int"
+        semanticModel={semanticModel}
       />
       <ActionDeleteButton onClick={handleDelete} />
     </ActionFieldContainer>

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/types.ts
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/types.ts
@@ -1,6 +1,7 @@
 /**
  * Shared types for action renderer components
  */
+import type { SemanticModel } from '../../../shared/types';
 
 export interface BaseActionRendererProps {
   action: any;
@@ -10,7 +11,7 @@ export interface BaseActionRendererProps {
   flushUpdate: () => void;
   handleKeyDown: (e: React.KeyboardEvent) => void;
   mainFieldRef: React.RefObject<HTMLInputElement>;
-  semanticModel?: any;
+  semanticModel?: SemanticModel;
   onNavigateToFunction?: (functionName: string) => void;
   onRenameFunction?: (oldName: string, newName: string) => void;
   dialogContextName?: string;

--- a/daedalus-dialog-editor/src/renderer/components/common/VariableAutocomplete.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/common/VariableAutocomplete.tsx
@@ -1,0 +1,226 @@
+import React, { useMemo } from 'react';
+import { Autocomplete, TextField, Box, Typography, Chip, createFilterOptions, TextFieldProps } from '@mui/material';
+import { useProjectStore } from '../../store/projectStore';
+import { GlobalConstant, GlobalVariable, SemanticModel } from '../../types/global';
+
+// Instance definition might not be strictly typed in global types yet
+interface InstanceDefinition {
+  name: string;
+  parent: string;
+  filePath?: string;
+  [key: string]: any;
+}
+
+export interface VariableAutocompleteProps {
+  /** Current value */
+  value: string;
+  /** Callback when value changes */
+  onChange: (value: string) => void;
+  /** Label for the input */
+  label?: string;
+  /** Placeholder for the input */
+  placeholder?: string;
+  /** Filter by variable/constant type (e.g. 'int', 'string') */
+  typeFilter?: string | string[];
+  /** Whether to include instances (e.g. NPCs, items) */
+  showInstances?: boolean;
+  /** Whether to allow values that are not in the list */
+  allowFreeInput?: boolean;
+  /** Custom styles */
+  sx?: any;
+  /** Whether to take full width */
+  fullWidth?: boolean;
+  /** Whether this is the main field (receives ref) */
+  isMainField?: boolean;
+  /** Ref for the main input field */
+  mainFieldRef?: React.RefObject<HTMLInputElement>;
+  /** Additional props to pass to the TextField */
+  textFieldProps?: Partial<TextFieldProps>;
+  /** Optional callback to flush updates (e.g. onBlur) */
+  onFlush?: () => void;
+  /** Optional keyboard event handler */
+  onKeyDown?: (e: React.KeyboardEvent) => void;
+  /** Optional semantic model to merge with global project model */
+  semanticModel?: SemanticModel;
+}
+
+type OptionType = {
+  name: string;
+  type: string;
+  source: 'variable' | 'constant' | 'instance';
+  filePath?: string;
+  value?: string | number | boolean;
+};
+
+const filter = createFilterOptions<OptionType>();
+
+const VariableAutocomplete: React.FC<VariableAutocompleteProps> = ({
+  value,
+  onChange,
+  label,
+  placeholder,
+  typeFilter,
+  showInstances = false,
+  allowFreeInput = true,
+  sx,
+  fullWidth = false,
+  isMainField = false,
+  mainFieldRef,
+  textFieldProps,
+  onFlush,
+  onKeyDown,
+  semanticModel
+}) => {
+  const { mergedSemanticModel } = useProjectStore();
+
+  const options = useMemo(() => {
+    const opts: OptionType[] = [];
+    const filters = typeFilter ? (Array.isArray(typeFilter) ? typeFilter : [typeFilter]) : null;
+
+    // Helper to check type
+    const isTypeMatch = (type: string) => {
+      if (!filters) return true;
+      return filters.includes(type);
+    };
+
+    // Add constants
+    const constants = { ...mergedSemanticModel.constants, ...semanticModel?.constants };
+    if (constants) {
+      Object.values(constants).forEach((c: GlobalConstant) => {
+        if (isTypeMatch(c.type)) {
+          // Avoid duplicates if merging
+          if (opts.some(o => o.name === c.name)) return;
+
+          opts.push({
+            name: c.name,
+            type: c.type,
+            source: 'constant',
+            filePath: c.filePath,
+            value: c.value
+          });
+        }
+      });
+    }
+
+    // Add variables
+    const variables = { ...mergedSemanticModel.variables, ...semanticModel?.variables };
+    if (variables) {
+      Object.values(variables).forEach((v: GlobalVariable) => {
+        if (isTypeMatch(v.type)) {
+          if (opts.some(o => o.name === v.name)) return;
+
+          opts.push({
+            name: v.name,
+            type: v.type,
+            source: 'variable',
+            filePath: v.filePath
+          });
+        }
+      });
+    }
+
+    // Add instances
+    if (showInstances) {
+      const instances = { ...mergedSemanticModel.instances, ...semanticModel?.instances };
+      if (instances) {
+        Object.values(instances).forEach((i: unknown) => {
+            const instance = i as InstanceDefinition;
+            // Instances usually have a class (parent), e.g., C_NPC, C_ITEM.
+            // If typeFilter is provided, we might want to match against the class name.
+            if (isTypeMatch(instance.parent || 'instance') || !filters) {
+                if (opts.some(o => o.name === instance.name)) return;
+
+                opts.push({
+                    name: instance.name,
+                    type: instance.parent || 'instance',
+                    source: 'instance',
+                    filePath: instance.filePath
+                });
+            }
+        });
+      }
+    }
+
+    return opts.sort((a, b) => a.name.localeCompare(b.name));
+  }, [mergedSemanticModel, semanticModel, typeFilter, showInstances]);
+
+  return (
+    <Autocomplete
+      value={value}
+      onChange={(_event, newValue) => {
+        if (typeof newValue === 'string') {
+          onChange(newValue);
+        } else if (newValue && newValue.name) {
+          onChange(newValue.name);
+        } else {
+          onChange('');
+        }
+      }}
+      inputValue={value}
+      onInputChange={(_event, newInputValue) => {
+        onChange(newInputValue);
+      }}
+      options={options}
+      getOptionLabel={(option) => {
+        // Value selected with enter, right from the input
+        if (typeof option === 'string') {
+          return option;
+        }
+        // Regular option
+        return option.name;
+      }}
+      filterOptions={(options, params) => {
+        const filtered = filter(options, params);
+        return filtered;
+      }}
+      freeSolo={allowFreeInput}
+      selectOnFocus
+      handleHomeEndKeys
+      renderOption={(props, option) => {
+          // Extract key to avoid passing it to li
+          const { key, ...otherProps } = props as any;
+          return (
+            <li key={key} {...otherProps}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
+                    {option.name}
+                  </Typography>
+                  <Chip
+                    label={option.type}
+                    size="small"
+                    variant="outlined"
+                    color={option.source === 'constant' ? 'primary' : option.source === 'instance' ? 'secondary' : 'default'}
+                    sx={{ height: 20, fontSize: '0.65rem' }}
+                  />
+                </Box>
+                {option.source === 'constant' && option.value !== undefined && (
+                   <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
+                      Value: {String(option.value)}
+                   </Typography>
+                )}
+              </Box>
+            </li>
+          );
+      }}
+      fullWidth={fullWidth}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          {...textFieldProps}
+          label={label}
+          placeholder={placeholder}
+          size="small"
+          inputRef={isMainField ? mainFieldRef : undefined}
+          onBlur={onFlush}
+          onKeyDown={onKeyDown}
+          sx={sx}
+        />
+      )}
+      sx={sx}
+      disableClearable={!allowFreeInput}
+    />
+  );
+};
+
+export default VariableAutocomplete;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,7 @@
       "workspaces": [
         "daedalus-dialog-editor",
         "daedalus-parser"
-      ],
-      "dependencies": {
-        "@rollup/rollup-linux-x64-gnu": "*"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.57.1"
-      }
+      ]
     },
     "daedalus-dialog-editor": {
       "version": "0.1.0",
@@ -2449,6 +2443,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
This PR adds a comprehensive autocomplete feature for variables in the dialog editor. It introduces a `VariableAutocomplete` component that leverages both the global project semantic model and the local file's semantic model to suggest variables, constants, and instances (like NPCs and items). This component is integrated into the Condition Editor and all relevant Action Renderers, significantly improving the user experience when editing complex dialog logic and actions.

---
*PR created automatically by Jules for task [5724058580603850952](https://jules.google.com/task/5724058580603850952) started by @daniel-daga*