### PR TITLE
Support for AI_StopProcessInfos, AI_PlayAni, and Variable Assignments in Dialog Editor

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/ActionCard.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/ActionCard.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useRef, useCallback, useMemo } from 'react';
 import { Box, Tooltip, Typography, Menu, MenuItem } from '@mui/material';
-import { Add as AddIcon, Chat as ChatIcon, CallSplit as CallSplitIcon, Description as DescriptionIcon, LibraryBooks as LibraryBooksIcon, SwapHoriz as SwapHorizIcon, Navigation as NavigationIcon, Code as CodeIcon, Inventory as InventoryIcon, CardGiftcard as CardGiftcardIcon, Gavel as GavelIcon, EmojiPeople as EmojiPeopleIcon } from '@mui/icons-material';
+import { Add as AddIcon, Chat as ChatIcon, CallSplit as CallSplitIcon, Description as DescriptionIcon, LibraryBooks as LibraryBooksIcon, SwapHoriz as SwapHorizIcon, Navigation as NavigationIcon, Code as CodeIcon, Inventory as InventoryIcon, CardGiftcard as CardGiftcardIcon, Gavel as GavelIcon, EmojiPeople as EmojiPeopleIcon, Edit as EditIcon, Stop as StopIcon, PlayArrow as PlayArrowIcon } from '@mui/icons-material';
 import { ActionCardProps } from './dialogTypes';
 import { getRendererForAction, getActionTypeLabel } from './actionRenderers';
 import { getActionType } from './actionTypes';
+import type { ActionTypeId } from './actionTypes';
 import type { BaseActionRendererProps } from './actionRenderers/types';
 import { shallowEqual } from '../utils/shallowEqual';
 
@@ -105,7 +106,7 @@ const ActionCard = React.memo(React.forwardRef<HTMLInputElement, ActionCardProps
     deleteActionAndFocusPrev(index);
   }, [deleteActionAndFocusPrev, index]);
 
-  const handleAddActionAfter = useCallback((actionType: string) => {
+  const handleAddActionAfter = useCallback((actionType: ActionTypeId) => {
     addActionAfter(index, actionType);
   }, [addActionAfter, index]);
 
@@ -133,21 +134,21 @@ const ActionCard = React.memo(React.forwardRef<HTMLInputElement, ActionCardProps
       flushUpdate();
       setMenuAnchor(actionBoxRef.current);
       setSelectedMenuIndex(0);
-    } else if (e.key === 'Enter' && e.shiftKey && isDialogLine && localAction.text && localAction.text.trim() !== '') {
+    } else if (e.key === 'Enter' && e.shiftKey && isDialogLine && (localAction as any).text && (localAction as any).text.trim() !== '') {
       // Shift+Enter creates a new dialog line WITHOUT toggling speaker
       e.preventDefault();
       flushUpdate();
       handleAddNewAfter(false);
-    } else if (e.key === 'Enter' && isDialogLine && localAction.text && localAction.text.trim() !== '') {
+    } else if (e.key === 'Enter' && isDialogLine && (localAction as any).text && (localAction as any).text.trim() !== '') {
       // Enter creates a new dialog line WITH toggling speaker (default behavior)
       e.preventDefault();
       flushUpdate();
       handleAddNewAfter(true);
-    } else if (e.key === 'Backspace' && isDialogLine && (!localAction.text || localAction.text.trim() === '')) {
+    } else if (e.key === 'Backspace' && isDialogLine && (!(localAction as any).text || (localAction as any).text.trim() === '')) {
       e.preventDefault();
       handleDeleteAndFocusPrev();
     }
-  }, [menuAnchor, isDialogLine, localAction.text, flushUpdate, handleTabToNext, handleTabToPrev, handleAddNewAfter, handleDeleteAndFocusPrev]);
+  }, [menuAnchor, isDialogLine, localAction, flushUpdate, handleTabToNext, handleTabToPrev, handleAddNewAfter, handleDeleteAndFocusPrev]);
 
   const getActionIcon = () => {
     switch (actionType) {
@@ -162,12 +163,15 @@ const ActionCard = React.memo(React.forwardRef<HTMLInputElement, ActionCardProps
       case 'setAttitudeAction': return <EmojiPeopleIcon fontSize="small" />;
       case 'chapterTransition': return <NavigationIcon fontSize="small" />;
       case 'exchangeRoutine': return <SwapHorizIcon fontSize="small" />;
+      case 'setVariableAction': return <EditIcon fontSize="small" />;
+      case 'stopProcessInfosAction': return <StopIcon fontSize="small" />;
+      case 'playAniAction': return <PlayArrowIcon fontSize="small" />;
       case 'customAction': return <CodeIcon fontSize="small" />;
-      default: return <Code fontSize="small" />;
+      default: return <CodeIcon fontSize="small" />;
     }
   };
 
-  const actionTypes = useMemo(() => [
+  const actionTypes = useMemo<{ type: ActionTypeId; label: string; icon: React.ReactNode }[]>(() => [
     { type: 'dialogLine', label: 'Dialog Line', icon: <ChatIcon fontSize="small" /> },
     { type: 'choice', label: 'Choice', icon: <CallSplitIcon fontSize="small" /> },
     { type: 'logEntry', label: 'Log Entry', icon: <DescriptionIcon fontSize="small" /> },
@@ -179,6 +183,9 @@ const ActionCard = React.memo(React.forwardRef<HTMLInputElement, ActionCardProps
     { type: 'setAttitudeAction', label: 'Set Attitude', icon: <EmojiPeopleIcon fontSize="small" /> },
     { type: 'chapterTransition', label: 'Chapter Transition', icon: <NavigationIcon fontSize="small" /> },
     { type: 'exchangeRoutine', label: 'Exchange Routine', icon: <SwapHorizIcon fontSize="small" /> },
+    { type: 'setVariableAction', label: 'Set Variable', icon: <EditIcon fontSize="small" /> },
+    { type: 'stopProcessInfosAction', label: 'End Dialog', icon: <StopIcon fontSize="small" /> },
+    { type: 'playAniAction', label: 'Play Animation', icon: <PlayArrowIcon fontSize="small" /> },
     { type: 'customAction', label: 'Custom Action', icon: <CodeIcon fontSize="small" /> },
   ], []);
 

--- a/daedalus-dialog-editor/src/renderer/components/actionFactory.ts
+++ b/daedalus-dialog-editor/src/renderer/components/actionFactory.ts
@@ -79,6 +79,18 @@ export function createAction(
       action = ACTION_TEMPLATES.exchangeRoutine();
       break;
 
+    case 'setVariableAction':
+      action = ACTION_TEMPLATES.setVariableAction();
+      break;
+
+    case 'stopProcessInfosAction':
+      action = ACTION_TEMPLATES.stopProcessInfosAction();
+      break;
+
+    case 'playAniAction':
+      action = ACTION_TEMPLATES.playAniAction();
+      break;
+
     case 'customAction':
       action = ACTION_TEMPLATES.customAction();
       break;

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/PlayAniActionRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/PlayAniActionRenderer.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import type { BaseActionRendererProps } from './types';
+import { ActionFieldContainer, ActionDeleteButton } from '../common';
+import VariableAutocomplete from '../common/VariableAutocomplete';
+import { TextField } from '@mui/material';
+
+const PlayAniActionRenderer: React.FC<BaseActionRendererProps> = ({
+  action,
+  handleUpdate,
+  handleDelete,
+  flushUpdate,
+  handleKeyDown,
+  mainFieldRef,
+  semanticModel
+}) => {
+  return (
+    <ActionFieldContainer>
+      <VariableAutocomplete
+        label="Target"
+        value={action.target || 'self'}
+        onChange={(value) => handleUpdate({ ...action, target: value })}
+        onFlush={flushUpdate}
+        onKeyDown={handleKeyDown}
+        isMainField
+        mainFieldRef={mainFieldRef}
+        sx={{ minWidth: 150 }}
+        semanticModel={semanticModel}
+        typeFilter="C_NPC"
+      />
+      <TextField
+        fullWidth
+        label="Animation Name"
+        value={action.animationName || ''}
+        onChange={(e) => handleUpdate({ ...action, animationName: e.target.value })}
+        onBlur={flushUpdate}
+        onKeyDown={handleKeyDown}
+        size="small"
+        variant="outlined"
+        placeholder="e.g. T_SEARCH"
+        sx={{ ml: 1 }}
+      />
+      <ActionDeleteButton onClick={handleDelete} />
+    </ActionFieldContainer>
+  );
+};
+
+export default PlayAniActionRenderer;

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/SetVariableActionRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/SetVariableActionRenderer.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import type { BaseActionRendererProps } from './types';
+import { ActionFieldContainer, ActionDeleteButton } from '../common';
+import { TextField, MenuItem } from '@mui/material';
+import VariableAutocomplete from '../common/VariableAutocomplete';
+
+const SetVariableActionRenderer: React.FC<BaseActionRendererProps> = ({
+  action,
+  handleUpdate,
+  handleDelete,
+  flushUpdate,
+  handleKeyDown,
+  mainFieldRef,
+  semanticModel
+}) => {
+  return (
+    <ActionFieldContainer>
+      <VariableAutocomplete
+        label="Variable"
+        value={action.variableName || ''}
+        onChange={(value) => handleUpdate({ ...action, variableName: value })}
+        onFlush={flushUpdate}
+        onKeyDown={handleKeyDown}
+        isMainField
+        mainFieldRef={mainFieldRef}
+        sx={{ minWidth: 200 }}
+        semanticModel={semanticModel}
+      />
+      <TextField
+        select
+        label="Op"
+        value={action.operator || '='}
+        onChange={(e) => {
+            handleUpdate({ ...action, operator: e.target.value });
+            flushUpdate();
+        }}
+        onKeyDown={handleKeyDown}
+        sx={{ width: 80, mx: 1 }}
+        size="small"
+        variant="outlined"
+      >
+        <MenuItem value="=">=</MenuItem>
+        <MenuItem value="+=">+=</MenuItem>
+        <MenuItem value="-=">-=</MenuItem>
+      </TextField>
+      <VariableAutocomplete
+        fullWidth
+        label="Value"
+        value={String(action.value !== undefined ? action.value : '')}
+        onChange={(value) => {
+            // Try to preserve number type if it looks like a number
+            const num = Number(value);
+            const isNum = !isNaN(num) && value.trim() !== '';
+            handleUpdate({ ...action, value: isNum ? num : value });
+        }}
+        onFlush={flushUpdate}
+        onKeyDown={handleKeyDown}
+        semanticModel={semanticModel}
+      />
+      <ActionDeleteButton onClick={handleDelete} />
+    </ActionFieldContainer>
+  );
+};
+
+export default SetVariableActionRenderer;

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/StopProcessInfosActionRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/StopProcessInfosActionRenderer.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import type { BaseActionRendererProps } from './types';
+import { ActionFieldContainer, ActionDeleteButton } from '../common';
+import VariableAutocomplete from '../common/VariableAutocomplete';
+import { Typography } from '@mui/material';
+
+const StopProcessInfosActionRenderer: React.FC<BaseActionRendererProps> = ({
+  action,
+  handleUpdate,
+  handleDelete,
+  flushUpdate,
+  handleKeyDown,
+  mainFieldRef,
+  semanticModel
+}) => {
+  return (
+    <ActionFieldContainer>
+      <Typography variant="body2" sx={{ mr: 2, whiteSpace: 'nowrap', fontWeight: 'bold', color: 'primary.main' }}>
+        End Dialog
+      </Typography>
+      <VariableAutocomplete
+        fullWidth
+        label="Target"
+        value={action.target || 'self'}
+        onChange={(value) => handleUpdate({ ...action, target: value })}
+        onFlush={flushUpdate}
+        onKeyDown={handleKeyDown}
+        isMainField
+        mainFieldRef={mainFieldRef}
+        semanticModel={semanticModel}
+        typeFilter="C_NPC"
+      />
+      <ActionDeleteButton onClick={handleDelete} />
+    </ActionFieldContainer>
+  );
+};
+
+export default StopProcessInfosActionRenderer;

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/index.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/index.tsx
@@ -19,6 +19,9 @@ import AttackActionRenderer from './AttackActionRenderer';
 import SetAttitudeActionRenderer from './SetAttitudeActionRenderer';
 import ChapterTransitionRenderer from './ChapterTransitionRenderer';
 import ExchangeRoutineRenderer from './ExchangeRoutineRenderer';
+import SetVariableActionRenderer from './SetVariableActionRenderer';
+import StopProcessInfosActionRenderer from './StopProcessInfosActionRenderer';
+import PlayAniActionRenderer from './PlayAniActionRenderer';
 import CustomActionRenderer from './CustomActionRenderer';
 import UnknownActionRenderer from './UnknownActionRenderer';
 
@@ -37,6 +40,9 @@ export const ACTION_RENDERERS: Record<ActionTypeId, React.FC<BaseActionRendererP
   setAttitudeAction: SetAttitudeActionRenderer,
   chapterTransition: ChapterTransitionRenderer,
   exchangeRoutine: ExchangeRoutineRenderer,
+  setVariableAction: SetVariableActionRenderer,
+  stopProcessInfosAction: StopProcessInfosActionRenderer,
+  playAniAction: PlayAniActionRenderer,
   customAction: CustomActionRenderer
 };
 
@@ -63,6 +69,9 @@ export const ACTION_TYPE_LABELS: Record<ActionTypeId, string> = {
   setAttitudeAction: 'Set Attitude',
   chapterTransition: 'Chapter Transition',
   exchangeRoutine: 'Exchange Routine',
+  setVariableAction: 'Set Variable',
+  stopProcessInfosAction: 'End Dialog',
+  playAniAction: 'Play Animation',
   customAction: 'Action'
 };
 

--- a/daedalus-dialog-editor/src/renderer/components/actionTemplates.ts
+++ b/daedalus-dialog-editor/src/renderer/components/actionTemplates.ts
@@ -15,6 +15,9 @@ import type {
   SetAttitudeAction,
   ChapterTransitionAction,
   ExchangeRoutineAction,
+  SetVariableAction,
+  StopProcessInfosAction,
+  PlayAniAction,
   CustomAction
 } from './actionTypes';
 
@@ -79,6 +82,21 @@ export const ACTION_TEMPLATES = {
   exchangeRoutine: (target: string = 'self', routine: string = 'START'): ExchangeRoutineAction => ({
     target,
     routine
+  }),
+
+  setVariableAction: (variableName: string = 'MIS_Quest', operator: string = '=', value: string | number | boolean = 'LOG_RUNNING'): SetVariableAction => ({
+    variableName,
+    operator,
+    value
+  }),
+
+  stopProcessInfosAction: (target: string = 'self'): StopProcessInfosAction => ({
+    target
+  }),
+
+  playAniAction: (target: string = 'self', animationName: string = 'T_SEARCH'): PlayAniAction => ({
+    target,
+    animationName
   }),
 
   customAction: (action: string = 'AI_StopProcessInfos(self)'): CustomAction => ({

--- a/daedalus-dialog-editor/src/renderer/components/actionTypes.ts
+++ b/daedalus-dialog-editor/src/renderer/components/actionTypes.ts
@@ -65,6 +65,21 @@ export interface ExchangeRoutineAction {
   routine: string;
 }
 
+export interface SetVariableAction {
+  variableName: string;
+  operator: string;
+  value: string | number | boolean;
+}
+
+export interface StopProcessInfosAction {
+  target: string;
+}
+
+export interface PlayAniAction {
+  target: string;
+  animationName: string;
+}
+
 export interface CustomAction {
   action: string;
 }
@@ -84,6 +99,9 @@ export type ActionType =
   | SetAttitudeAction
   | ChapterTransitionAction
   | ExchangeRoutineAction
+  | SetVariableAction
+  | StopProcessInfosAction
+  | PlayAniAction
   | CustomAction;
 
 /**
@@ -101,6 +119,9 @@ export type ActionTypeId =
   | 'setAttitudeAction'
   | 'chapterTransition'
   | 'exchangeRoutine'
+  | 'setVariableAction'
+  | 'stopProcessInfosAction'
+  | 'playAniAction'
   | 'customAction';
 
 /**
@@ -140,6 +161,20 @@ export function getActionType(action: any): ActionTypeId {
   }
   if ((action.npc !== undefined || action.target !== undefined) && action.routine !== undefined && action.attitude === undefined) {
     return 'exchangeRoutine';
+  }
+  if (action.variableName !== undefined && action.operator !== undefined && action.value !== undefined) {
+    return 'setVariableAction';
+  }
+  if (action.target !== undefined && action.animationName !== undefined) {
+    return 'playAniAction';
+  }
+  // Loose check for StopProcessInfos - assuming it only has target
+  if (action.target !== undefined &&
+      action.item === undefined &&
+      action.attitude === undefined &&
+      action.routine === undefined &&
+      action.animationName === undefined) {
+    return 'stopProcessInfosAction';
   }
   if (action.action !== undefined) {
     return 'customAction';

--- a/daedalus-dialog-editor/tests/SetVariableActionRenderer.test.tsx
+++ b/daedalus-dialog-editor/tests/SetVariableActionRenderer.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SetVariableActionRenderer from '../src/renderer/components/actionRenderers/SetVariableActionRenderer';
+import { SetVariableAction } from '../src/renderer/components/actionTypes';
+
+// Mock VariableAutocomplete to simplify testing (it might be complex)
+// Using a simple input for testing
+jest.mock('../src/renderer/components/common/VariableAutocomplete', () => {
+  return function MockVariableAutocomplete(props: any) {
+    return (
+      <div data-testid={`autocomplete-${props.label}`}>
+        <label>{props.label}</label>
+        <input
+            value={props.value}
+            onChange={(e) => props.onChange(e.target.value)}
+            onKeyDown={props.onKeyDown}
+        />
+      </div>
+    );
+  };
+});
+
+describe('SetVariableActionRenderer', () => {
+  const mockAction: SetVariableAction = {
+    variableName: 'MIS_Test',
+    operator: '=',
+    value: 'LOG_RUNNING'
+  };
+
+  const mockProps = {
+    action: mockAction,
+    index: 0,
+    totalActions: 1,
+    npcName: 'TestNPC',
+    handleUpdate: jest.fn(),
+    handleDelete: jest.fn(),
+    flushUpdate: jest.fn(),
+    handleKeyDown: jest.fn(),
+    mainFieldRef: { current: null },
+    semanticModel: {} as any
+  };
+
+  test('renders variable name, operator and value', () => {
+    render(<SetVariableActionRenderer {...mockProps} />);
+
+    // Check Variable Name (Autocomplete mock)
+    expect(screen.getByTestId('autocomplete-Variable')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('MIS_Test')).toBeInTheDocument();
+
+    // Check Operator (Select/TextField)
+    // MUI Select uses hidden input, but display value should be visible?
+    // TextField select renders an input with value.
+    // We can check by display value.
+    expect(screen.getByDisplayValue('=')).toBeInTheDocument();
+
+    // Check Value (Autocomplete mock)
+    expect(screen.getByTestId('autocomplete-Value')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('LOG_RUNNING')).toBeInTheDocument();
+  });
+
+  test('calls handleUpdate when variable name changes', () => {
+    render(<SetVariableActionRenderer {...mockProps} />);
+
+    const variableInput = screen.getByTestId('autocomplete-Variable').querySelector('input');
+    fireEvent.change(variableInput!, { target: { value: 'NewVar' } });
+
+    expect(mockProps.handleUpdate).toHaveBeenCalledWith({
+      ...mockAction,
+      variableName: 'NewVar'
+    });
+  });
+});

--- a/daedalus-parser/src/semantic/parsers/action-parsers.ts
+++ b/daedalus-parser/src/semantic/parsers/action-parsers.ts
@@ -14,7 +14,9 @@ import {
   AttackAction,
   SetAttitudeAction,
   ExchangeRoutineAction,
-  ChapterTransitionAction
+  ChapterTransitionAction,
+  StopProcessInfosAction,
+  PlayAniAction
 } from '../semantic-model';
 
 export class ActionParsers {
@@ -46,6 +48,10 @@ export class ActionParsers {
         return ActionParsers.parseExchangeRoutineCall(node);
       case 'B_Kapitelwechsel':
         return ActionParsers.parseChapterTransitionCall(node);
+      case 'AI_StopProcessInfos':
+        return ActionParsers.parseStopProcessInfosCall(node);
+      case 'AI_PlayAni':
+        return ActionParsers.parsePlayAniCall(node);
       default:
         return ActionParsers.parseGenericAction(node);
     }
@@ -177,6 +183,24 @@ export class ActionParsers {
   static parseChapterTransitionCall(node: TreeSitterNode): ChapterTransitionAction | null {
     return ActionParsers.parseActionWithArgs(node, 2, (args) =>
       new ChapterTransitionAction(parseInt(args[0]) || 1, args[1])
+    );
+  }
+
+  /**
+   * Parse AI_StopProcessInfos function call
+   */
+  static parseStopProcessInfosCall(node: TreeSitterNode): StopProcessInfosAction | null {
+    return ActionParsers.parseActionWithArgs(node, 1, (args) =>
+      new StopProcessInfosAction(args[0])
+    );
+  }
+
+  /**
+   * Parse AI_PlayAni function call
+   */
+  static parsePlayAniCall(node: TreeSitterNode): PlayAniAction | null {
+    return ActionParsers.parseActionWithArgs(node, 2, (args) =>
+      new PlayAniAction(args[0], args[1])
     );
   }
 

--- a/daedalus-parser/test/missing_actions.test.js
+++ b/daedalus-parser/test/missing_actions.test.js
@@ -1,0 +1,62 @@
+const { test } = require('node:test');
+const { strict: assert } = require('node:assert');
+const DaedalusParser = require('../src/core/parser');
+const { SemanticModelBuilderVisitor } = require('../dist/semantic/semantic-visitor');
+
+test('should detect missing actions and structures', () => {
+    const source = `
+    func void DIA_Test_Info() {
+        AI_Output(self, other, "DIA_Test_01"); // DialogLine
+
+        AI_StopProcessInfos(self);             // Should be detected
+        AI_PlayAni(self, "T_SEARCH");          // Should be detected
+        AI_StartState(self, ZS_Talk, 1, "");   // Should be detected
+
+        MIS_TestQuest = LOG_RUNNING;           // Variable assignment - Should be detected
+    };
+    `;
+
+    // 1. Parse
+    const parser = new DaedalusParser();
+    const result = parser.parse(source);
+    assert.equal(result.hasErrors, false, 'Should parse without errors');
+
+    // 2. Build Semantic Model
+    const visitor = new SemanticModelBuilderVisitor();
+    visitor.pass1_createObjects(result.rootNode);
+    visitor.pass2_analyzeAndLink(result.rootNode);
+
+    const func = visitor.semanticModel.functions['DIA_Test_Info'];
+    assert.ok(func, 'Function should be found');
+
+    const actions = func.actions;
+
+    console.log('Actions found:', JSON.stringify(actions, null, 2));
+
+    // Check AI_Output (Baseline)
+    const outputAction = actions.find(a => a.constructor.name === 'DialogLine');
+    assert.ok(outputAction, 'Should find DialogLine action');
+
+    // Check AI_StopProcessInfos
+    // Now parsed as specific class
+    const stopAction = actions.find(a => a.constructor.name === 'StopProcessInfosAction');
+    assert.ok(stopAction, 'Should find StopProcessInfosAction');
+    if (stopAction) {
+        assert.equal(stopAction.target, 'self', 'StopProcessInfos target should be self');
+    }
+
+    // Check AI_PlayAni
+    const playAniAction = actions.find(a => a.constructor.name === 'PlayAniAction');
+    assert.ok(playAniAction, 'Should find PlayAniAction');
+    if (playAniAction) {
+        assert.equal(playAniAction.animationName, 'T_SEARCH', 'PlayAni animation should be T_SEARCH');
+    }
+
+    // Check Variable Assignment
+    const assignmentAction = actions.find(a => a.constructor.name === 'SetVariableAction');
+    assert.ok(assignmentAction, 'Should find SetVariableAction');
+    if (assignmentAction) {
+        assert.equal(assignmentAction.variableName, 'MIS_TestQuest', 'Variable name should be MIS_TestQuest');
+        assert.equal(assignmentAction.value, 'LOG_RUNNING', 'Value should be LOG_RUNNING');
+    }
+});


### PR DESCRIPTION
Implemented parser support and frontend components for `AI_StopProcessInfos`, `AI_PlayAni`, and in-function variable assignments (e.g. `MIS_Quest = LOG_RUNNING`). This allows the dialog editor to visualize and edit these common Gothic scripting constructs. Includes regression tests for parser and new renderer unit test.

---
*PR created automatically by Jules for task [7710994585857627582](https://jules.google.com/task/7710994585857627582) started by @daniel-daga*