### PR TITLE
⚡ Bolt: Optimize ConditionCard rendering performance

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/ConditionEditor.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/ConditionEditor.tsx
@@ -1,16 +1,3 @@
-import React, { useState, useCallback, useRef } from 'react';
-import { Box, Paper, Typography, Stack, IconButton, Tooltip, Button, Menu, MenuItem, Chip } from '@mui/material';
-import { Add as AddIcon, ExpandMore as ExpandMoreIcon, ChevronRight as ChevronRightIcon, Code as CodeIcon, Check as CheckIcon, Info as InfoIcon } from '@mui/icons-material';
-import ConditionCard from './ConditionCard';
-
-interface ConditionEditorProps {
-  conditionFunction: any;
-  onUpdateFunction: (funcOrUpdater: any | ((func: any) => any)) => void;
-  semanticModel?: any;
-  filePath: string;
-  dialogName: string;
-}
-
 import React, { useState, useCallback, useRef, useMemo } from 'react';
 import { Box, Paper, Typography, Stack, IconButton, Tooltip, Button, Menu, MenuItem, Chip } from '@mui/material';
 import { Add as AddIcon, ExpandMore as ExpandMoreIcon, ChevronRight as ChevronRightIcon, Code as CodeIcon, Check as CheckIcon, Info as InfoIcon } from '@mui/icons-material';
@@ -249,6 +236,7 @@ const ConditionEditor = React.memo<ConditionEditorProps>(({
                     deleteCondition={deleteCondition}
                     focusCondition={focusCondition}
                     semanticModel={semanticModel}
+                    filePath={filePath}
                   />
                 ))}
               </Stack>


### PR DESCRIPTION
💡 What: Optimized `ConditionCard` to avoid re-rendering when the monolithic `semanticModel` updates but the condition itself hasn't changed.
🎯 Why: `ConditionCard` was re-rendering on every keystroke in other parts of the file because `semanticModel` is recreated on every edit. This caused unnecessary work for the React renderer, especially when many conditions exist.
📊 Impact: `ConditionCard` only re-renders when the `condition` object value actually changes (verified via deep comparison) or other primitive props change.
micro-optimization: `VariableAutocomplete` now intelligently fetches the latest `semanticModel` from `useEditorStore` (using `filePath`) if provided, ensuring it always has fresh data for suggestions even if its parent (`ConditionCard`) didn't re-render.
🔬 Measurement: Verified that `ConditionCard.test.tsx` passes. Performance benefit is implicit by reducing the number of renders during typing.

---
*PR created automatically by Jules for task [2913789867983210466](https://jules.google.com/task/2913789867983210466) started by @daniel-daga*