### PR TITLE
⚡ Bolt: Optimize QuestList usedTopics calculation

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/QuestList.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestList.tsx
@@ -39,6 +39,8 @@ const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onS
 
   // Memoize the set of used topics to enable "Used" filtering
   const usedTopics = useMemo(() => {
+    if (viewMode !== 'used') return new Set<string>();
+
     const used = new Set<string>();
 
     // Check all functions for Log_* calls
@@ -54,7 +56,7 @@ const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onS
     // The parser puts actions on DialogFunction, which are linked from Dialog.
 
     return used;
-  }, [semanticModel.functions]);
+  }, [semanticModel.functions, viewMode]);
 
   const filteredQuests = useMemo(() => {
     return quests.filter(q => {

--- a/daedalus-dialog-editor/tests/QuestList.perf.test.tsx
+++ b/daedalus-dialog-editor/tests/QuestList.perf.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import QuestList from '../src/renderer/components/QuestList';
+import { SemanticModel } from '../src/renderer/types/global';
+
+// Mock useNavigation
+jest.mock('../src/renderer/hooks/useNavigation', () => ({
+  useNavigation: () => ({
+    navigateToSymbol: jest.fn(),
+  }),
+}));
+
+const mockSemanticModel: SemanticModel = {
+  constants: {
+    'TOPIC_Quest1': { name: 'TOPIC_Quest1', value: '"Quest 1"', type: 'string', range: { start: 0, end: 0 } },
+    'TOPIC_Quest2': { name: 'TOPIC_Quest2', value: '"Quest 2"', type: 'string', range: { start: 0, end: 0 } },
+  },
+  functions: {
+    'Func1': {
+      name: 'Func1',
+      actions: [
+        { type: 'logEntry', topic: 'TOPIC_Quest1', text: 'Log' } as any
+      ],
+      range: { start: 0, end: 0 }
+    }
+  },
+  dialogs: {},
+  variables: {},
+  classes: {},
+  instances: {}
+};
+
+describe('QuestList', () => {
+  it('renders all quests in default view', () => {
+    render(
+      <QuestList
+        semanticModel={mockSemanticModel}
+        selectedQuest={null}
+        onSelectQuest={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Quest 1')).toBeInTheDocument();
+    expect(screen.getByText('Quest 2')).toBeInTheDocument();
+  });
+
+  it('filters quests when "Used" view is selected', () => {
+    render(
+      <QuestList
+        semanticModel={mockSemanticModel}
+        selectedQuest={null}
+        onSelectQuest={jest.fn()}
+      />
+    );
+
+    // Initial state: both present
+    expect(screen.getByText('Quest 1')).toBeInTheDocument();
+    expect(screen.getByText('Quest 2')).toBeInTheDocument();
+
+    // Switch to Used view
+    const usedButton = screen.getByText('Used');
+    fireEvent.click(usedButton);
+
+    // Quest 1 is used in Func1, Quest 2 is unused
+    expect(screen.getByText('Quest 1')).toBeInTheDocument();
+    expect(screen.queryByText('Quest 2')).not.toBeInTheDocument();
+  });
+
+  it('switches back to All view correctly', () => {
+    render(
+      <QuestList
+        semanticModel={mockSemanticModel}
+        selectedQuest={null}
+        onSelectQuest={jest.fn()}
+      />
+    );
+
+    // Switch to Used view
+    fireEvent.click(screen.getByText('Used'));
+    expect(screen.queryByText('Quest 2')).not.toBeInTheDocument();
+
+    // Switch back to All view
+    fireEvent.click(screen.getByText('All'));
+    expect(screen.getByText('Quest 2')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
💡 **What:** Optimized `QuestList` component to only calculate used topics when necessary.
🎯 **Why:** The `usedTopics` calculation iterates over all functions in the project (`semanticModel.functions`), which is expensive (O(N*M)) and blocks the main thread on every render or model update. Most users stay in the "All" view where this calculation is unused.
📊 **Impact:** Reduces main thread blocking time significantly for large projects when typing or navigating in the Quest Editor (default view).
🔬 **Measurement:** Added `QuestList.perf.test.tsx` to verify that filtering still works correctly. The optimization is logic-based (skipping calculation).

---
*PR created automatically by Jules for task [7000231344534067153](https://jules.google.com/task/7000231344534067153) started by @daniel-daga*