### PR TITLE
⚡ Bolt: Virtualize QuestList and optimize usedTopics calculation

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/QuestList.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestList.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import {
   Box,
-  List,
   ListItem,
   ListItemButton,
   ListItemText,
@@ -15,6 +14,8 @@ import {
   Tooltip
 } from '@mui/material';
 import { Search as SearchIcon, Add as AddIcon, OpenInNew as OpenInNewIcon } from '@mui/icons-material';
+import { FixedSizeList, ListChildComponentProps } from 'react-window';
+import AutoSizer from 'react-virtualized-auto-sizer';
 import type { SemanticModel } from '../types/global';
 import CreateQuestDialog from './CreateQuestDialog';
 import { useNavigation } from '../hooks/useNavigation';
@@ -24,6 +25,45 @@ interface QuestListProps {
   selectedQuest: string | null;
   onSelectQuest: (questName: string) => void;
 }
+
+const Row = ({ index, style, data }: ListChildComponentProps) => {
+  const { quests, selectedQuest, onSelectQuest, navigateToSymbol } = data;
+  const quest = quests[index];
+
+  return (
+    <ListItem
+      style={style}
+      key={quest.name}
+      disablePadding
+      component="div"
+      secondaryAction={
+        <Tooltip title="Follow reference" arrow>
+          <IconButton
+            edge="end"
+            size="small"
+            onClick={(e) => {
+              e.stopPropagation();
+              navigateToSymbol(quest.name);
+            }}
+          >
+            <OpenInNewIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      }
+    >
+      <ListItemButton
+        selected={selectedQuest === quest.name}
+        onClick={() => onSelectQuest(quest.name)}
+        style={{ height: '100%' }}
+      >
+        <ListItemText
+          primary={String(quest.value).replace(/^"|"$/g, '')} // Strip quotes for display
+          secondary={quest.name}
+        />
+      </ListItemButton>
+    </ListItem>
+  );
+};
 
 const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onSelectQuest }) => {
   const { navigateToSymbol } = useNavigation();
@@ -38,7 +78,12 @@ const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onS
   }, [semanticModel.constants]);
 
   // Memoize the set of used topics to enable "Used" filtering
+  // Optimization: Only calculate when needed to avoid expensive iteration
   const usedTopics = useMemo(() => {
+    if (viewMode !== 'used') {
+      return new Set<string>();
+    }
+
     const used = new Set<string>();
 
     // Check all functions for Log_* calls
@@ -50,11 +95,8 @@ const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onS
       });
     });
 
-    // Also check dialog information functions (if any actions are directly on dialogs, though actions are usually on functions)
-    // The parser puts actions on DialogFunction, which are linked from Dialog.
-
     return used;
-  }, [semanticModel.functions]);
+  }, [semanticModel.functions, viewMode]);
 
   const filteredQuests = useMemo(() => {
     return quests.filter(q => {
@@ -70,6 +112,13 @@ const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onS
       return true;
     });
   }, [quests, filter, viewMode, usedTopics]);
+
+  const itemData = useMemo(() => ({
+    quests: filteredQuests,
+    selectedQuest,
+    onSelectQuest,
+    navigateToSymbol
+  }), [filteredQuests, selectedQuest, onSelectQuest, navigateToSymbol]);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', borderRight: 1, borderColor: 'divider' }}>
@@ -109,43 +158,29 @@ const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onS
         </ToggleButtonGroup>
       </Box>
       <Divider />
-      <List sx={{ flexGrow: 1, overflow: 'auto' }}>
-        {filteredQuests.map((quest) => (
-          <ListItem 
-            key={quest.name} 
-            disablePadding
-            secondaryAction={
-              <Tooltip title="Follow reference" arrow>
-                <IconButton 
-                  edge="end" 
-                  size="small" 
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    navigateToSymbol(quest.name);
-                  }}
-                >
-                  <OpenInNewIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-            }
-          >
-            <ListItemButton
-              selected={selectedQuest === quest.name}
-              onClick={() => onSelectQuest(quest.name)}
-            >
-              <ListItemText
-                primary={String(quest.value).replace(/^"|"$/g, '')} // Strip quotes for display
-                secondary={quest.name}
-              />
-            </ListItemButton>
-          </ListItem>
-        ))}
-        {filteredQuests.length === 0 && (
-          <ListItem>
-            <ListItemText secondary="No quests found" />
-          </ListItem>
+      <Box sx={{ flexGrow: 1, overflow: 'hidden' }}>
+        {filteredQuests.length > 0 ? (
+          <AutoSizer>
+            {({ height, width }) => (
+              <FixedSizeList
+                height={height}
+                width={width}
+                itemSize={72} // Height for ListItem with secondary text
+                itemCount={filteredQuests.length}
+                itemData={itemData}
+              >
+                {Row}
+              </FixedSizeList>
+            )}
+          </AutoSizer>
+        ) : (
+          <Box sx={{ p: 2, textAlign: 'center' }}>
+            <Typography variant="body2" color="text.secondary">
+              No quests found
+            </Typography>
+          </Box>
         )}
-      </List>
+      </Box>
       <CreateQuestDialog open={isCreateDialogOpen} onClose={() => setIsCreateDialogOpen(false)} />
     </Box>
   );

--- a/daedalus-dialog-editor/tests/QuestList.test.tsx
+++ b/daedalus-dialog-editor/tests/QuestList.test.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import QuestList from '../src/renderer/components/QuestList';
+import '@testing-library/jest-dom';
+import { SemanticModel } from '../src/renderer/types/global';
+
+// Mock useNavigation
+const mockNavigateToSymbol = jest.fn();
+jest.mock('../src/renderer/hooks/useNavigation', () => ({
+  useNavigation: () => ({
+    navigateToSymbol: mockNavigateToSymbol,
+  }),
+}));
+
+// Mock react-virtualized-auto-sizer
+jest.mock('react-virtualized-auto-sizer', () => ({
+  __esModule: true,
+  default: ({ children }: any) => children({ height: 500, width: 250 }),
+}));
+
+// Mock CreateQuestDialog
+jest.mock('../src/renderer/components/CreateQuestDialog', () => {
+  return function MockCreateQuestDialog({ open, onClose }: any) {
+    if (!open) return null;
+    return (
+      <div data-testid="create-quest-dialog">
+        <button onClick={onClose}>Close</button>
+      </div>
+    );
+  };
+});
+
+describe('QuestList', () => {
+  const mockOnSelectQuest = jest.fn();
+
+  const mockSemanticModel: SemanticModel = {
+    hasErrors: false,
+    errors: [],
+    constants: {
+      'TOPIC_Test1': { name: 'TOPIC_Test1', type: 'string', value: '"Test Quest 1"', filePath: 'file1.d' },
+      'TOPIC_Test2': { name: 'TOPIC_Test2', type: 'string', value: '"Test Quest 2"', filePath: 'file1.d' },
+      'TOPIC_Unused': { name: 'TOPIC_Unused', type: 'string', value: '"Unused Quest"', filePath: 'file1.d' },
+      'OTHER_CONST': { name: 'OTHER_CONST', type: 'int', value: 123, filePath: 'file1.d' },
+    },
+    functions: {
+      'Func_Used_Quest': {
+        name: 'Func_Used_Quest',
+        returnType: 'VOID',
+        actions: [
+          {
+            topic: 'TOPIC_Test1',
+            text: 'Log entry',
+            // duck-typed as LogEntryAction
+          } as any
+        ],
+        conditions: [],
+        calls: []
+      },
+      'Func_Used_Quest2': {
+        name: 'Func_Used_Quest2',
+        returnType: 'VOID',
+        actions: [
+            // This one is used via CreateTopicAction
+          {
+            topic: 'TOPIC_Test2',
+            topicType: 'LOG_MISSION',
+            // duck-typed as CreateTopicAction
+          } as any
+        ],
+        conditions: [],
+        calls: []
+      }
+    },
+    dialogs: {},
+    variables: {},
+    instances: {}
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all quests initially (All view)', () => {
+    render(
+      <QuestList
+        semanticModel={mockSemanticModel}
+        selectedQuest={null}
+        onSelectQuest={mockOnSelectQuest}
+      />
+    );
+
+    expect(screen.getByText('Test Quest 1')).toBeInTheDocument();
+    expect(screen.getByText('Test Quest 2')).toBeInTheDocument();
+    expect(screen.getByText('Unused Quest')).toBeInTheDocument();
+    expect(screen.queryByText('123')).not.toBeInTheDocument(); // OTHER_CONST should not be shown
+  });
+
+  it('filters quests by search text', async () => {
+    const user = userEvent.setup();
+    render(
+      <QuestList
+        semanticModel={mockSemanticModel}
+        selectedQuest={null}
+        onSelectQuest={mockOnSelectQuest}
+      />
+    );
+
+    const searchInput = screen.getByPlaceholderText('Search quests...');
+    await user.type(searchInput, 'Test Quest 1');
+
+    expect(screen.getByText('Test Quest 1')).toBeInTheDocument();
+    expect(screen.queryByText('Test Quest 2')).not.toBeInTheDocument();
+    expect(screen.queryByText('Unused Quest')).not.toBeInTheDocument();
+  });
+
+  it('filters quests by "Used" view mode', async () => {
+    const user = userEvent.setup();
+    render(
+      <QuestList
+        semanticModel={mockSemanticModel}
+        selectedQuest={null}
+        onSelectQuest={mockOnSelectQuest}
+      />
+    );
+
+    // Switch to Used view
+    const usedButton = screen.getByRole('button', { name: /^Used$/i });
+    await user.click(usedButton);
+
+    expect(screen.getByText('Test Quest 1')).toBeInTheDocument();
+    expect(screen.getByText('Test Quest 2')).toBeInTheDocument();
+    expect(screen.queryByText('Unused Quest')).not.toBeInTheDocument();
+  });
+
+  it('calls onSelectQuest when a quest is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <QuestList
+        semanticModel={mockSemanticModel}
+        selectedQuest={null}
+        onSelectQuest={mockOnSelectQuest}
+      />
+    );
+
+    await user.click(screen.getByText('Test Quest 1'));
+    expect(mockOnSelectQuest).toHaveBeenCalledWith('TOPIC_Test1');
+  });
+
+  it('opens create quest dialog', async () => {
+    const user = userEvent.setup();
+    render(
+      <QuestList
+        semanticModel={mockSemanticModel}
+        selectedQuest={null}
+        onSelectQuest={mockOnSelectQuest}
+      />
+    );
+
+    const addButton = screen.getByRole('button', { name: /Create New Quest/i }); // Assuming tooltip text is accessible or I can find by icon
+    // Wait, tooltip adds title attribute, often accessible via aria-label or title.
+    // The button has <AddIcon /> inside.
+    // The previous code had `Tooltip title="Create New Quest"`.
+    // The `IconButton` inside `Tooltip` gets `aria-label` from title if not provided?
+    // Let's try `screen.getByRole('button', { name: /Create New Quest/i })` first.
+    // If not, I'll inspect.
+
+    await user.click(addButton);
+    expect(screen.getByTestId('create-quest-dialog')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
💡 **What:** Optimized `QuestList` component by implementing list virtualization using `react-window` and deferring the expensive `usedTopics` calculation.

🎯 **Why:** 
1.  **Rendering Performance:** The `QuestList` rendered all items at once. For large projects with many quests (topics), this caused significant DOM overhead.
2.  **Calculation Overhead:** The `usedTopics` calculation iterated over all functions and actions in the semantic model on every update, even when the "Used" filter was not active. This was O(N) where N is the total number of actions in the project.

📊 **Impact:**
-   **Initial Render:** Faster initial render of the Quest Editor as it only renders visible items (~10 items instead of potentially hundreds).
-   **Updates:** Reduced CPU usage during typing or model updates when "Used" filter is not active.
-   **Memory:** Reduced DOM node count.

 microscopio **Measurement:**
-   Verified with `daedalus-dialog-editor/tests/QuestList.test.tsx`.
-   Verified frontend visually using Playwright script (screenshot confirmed layout).


---
*PR created automatically by Jules for task [16088556726327556342](https://jules.google.com/task/16088556726327556342) started by @daniel-daga*