### PR TITLE
Make Quest Editor references clickable

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/QuestEditor/Nodes/BaseNode.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestEditor/Nodes/BaseNode.tsx
@@ -3,7 +3,7 @@ import { Box, Typography, Paper } from '@mui/material';
 import { Handle, Position } from 'reactflow';
 
 export interface BaseNodeProps {
-  label: string;
+  label: string | React.ReactNode;
   headerColor?: string;
   icon?: React.ReactNode;
   children?: React.ReactNode;
@@ -45,7 +45,7 @@ const BaseNode: React.FC<BaseNodeProps> = ({
         }}
       >
         {icon && <Box component="span" sx={{ display: 'flex', opacity: 0.8 }}>{icon}</Box>}
-        <Typography variant="subtitle2" sx={{ fontWeight: 'bold', fontSize: '0.9rem', color: '#fff' }}>
+        <Typography variant="subtitle2" component="div" sx={{ fontWeight: 'bold', fontSize: '0.9rem', color: '#fff' }}>
           {label}
         </Typography>
       </Box>

--- a/daedalus-dialog-editor/src/renderer/components/QuestEditor/Nodes/ConditionNode.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestEditor/Nodes/ConditionNode.tsx
@@ -3,19 +3,21 @@ import { Handle, Position, NodeProps } from 'reactflow';
 import { Box, Typography } from '@mui/material';
 import { HelpOutline } from '@mui/icons-material';
 import BaseNode from './BaseNode';
+import ReferenceLink from '../../common/ReferenceLink';
+import ExpressionText from '../../common/ExpressionText';
 
 const ConditionNode: React.FC<NodeProps> = ({ data, selected }) => {
   return (
     <BaseNode
-      label={data.label || 'Condition'}
+      label={<ReferenceLink symbolName={data.label || ''} sx={{ color: '#fff' }}>{data.label || 'Condition'}</ReferenceLink>}
       headerColor="#ffc107" // Amber
       icon={<HelpOutline fontSize="small" />}
       selected={selected}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
         <Box sx={{ bgcolor: '#1a1a1a', p: 1, borderRadius: 1 }}>
-          <Typography variant="body2" sx={{ fontSize: 11, fontFamily: 'monospace', color: '#81d4fa' }}>
-            {data.expression || 'TRUE'}
+          <Typography variant="body2" component="div" sx={{ fontSize: 11, fontFamily: 'monospace', color: '#81d4fa' }}>
+            <ExpressionText expression={data.expression || 'TRUE'} />
           </Typography>
         </Box>
 

--- a/daedalus-dialog-editor/src/renderer/components/QuestEditor/Nodes/DialogNode.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestEditor/Nodes/DialogNode.tsx
@@ -3,19 +3,20 @@ import { Handle, Position, NodeProps } from 'reactflow';
 import { Box, Typography } from '@mui/material';
 import { ChatBubbleOutline } from '@mui/icons-material';
 import BaseNode from './BaseNode';
+import ReferenceLink from '../../common/ReferenceLink';
 
 const DialogNode: React.FC<NodeProps> = ({ data, selected }) => {
   return (
     <BaseNode
-      label={data.label || 'Dialog'}
+      label={<ReferenceLink symbolName={data.label || ''} sx={{ color: '#fff' }}>{data.label || 'Dialog'}</ReferenceLink>}
       headerColor="#3f51b5" // Blue
       icon={<ChatBubbleOutline fontSize="small" />}
       selected={selected}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-        <Typography variant="caption" sx={{ color: '#aaa', fontSize: 10 }}>
+        <ReferenceLink symbolName={data.npc || ''} variant="caption" sx={{ color: '#aaa', fontSize: 10, display: 'block' }}>
           {data.npc || 'Unknown NPC'}
-        </Typography>
+        </ReferenceLink>
 
         <Box sx={{ bgcolor: '#1a1a1a', p: 1, borderRadius: 1, maxHeight: 60, overflow: 'hidden' }}>
           <Typography variant="body2" sx={{ fontSize: 11, fontStyle: 'italic', color: '#ccc' }}>

--- a/daedalus-dialog-editor/src/renderer/components/QuestEditor/Nodes/QuestStateNode.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestEditor/Nodes/QuestStateNode.tsx
@@ -3,6 +3,7 @@ import { Handle, Position, NodeProps } from 'reactflow';
 import { Box, Typography } from '@mui/material';
 import { CheckCircleOutline, ErrorOutline, PlaylistPlay } from '@mui/icons-material';
 import BaseNode from './BaseNode';
+import ReferenceLink from '../../common/ReferenceLink';
 
 const QuestStateNode: React.FC<NodeProps> = ({ data, selected }) => {
   let icon = <PlaylistPlay fontSize="small" />;
@@ -21,15 +22,15 @@ const QuestStateNode: React.FC<NodeProps> = ({ data, selected }) => {
 
   return (
     <BaseNode
-      label={data.label || 'Quest State'}
+      label={<ReferenceLink symbolName={data.label || ''} sx={{ color: '#fff' }}>{data.label || 'Quest State'}</ReferenceLink>}
       headerColor={color}
       icon={icon}
       selected={selected}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-        <Typography variant="caption" sx={{ color: '#aaa', fontSize: 10 }}>
+        <ReferenceLink symbolName={data.variableName || ''} variant="caption" sx={{ color: '#aaa', fontSize: 10, display: 'block' }}>
           {data.variableName || 'MIS_Unknown'}
-        </Typography>
+        </ReferenceLink>
 
         <Box sx={{ bgcolor: '#1a1a1a', p: 1, borderRadius: 1 }}>
           <Typography variant="body2" sx={{ fontSize: 11, color: '#ccc', fontWeight: 'bold' }}>

--- a/daedalus-dialog-editor/src/renderer/components/common/ExpressionText.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/common/ExpressionText.tsx
@@ -1,0 +1,40 @@
+import React, { useMemo } from 'react';
+import ReferenceLink from './ReferenceLink';
+
+interface ExpressionTextProps {
+  expression: string;
+}
+
+const ExpressionText: React.FC<ExpressionTextProps> = ({ expression }) => {
+  const parts = useMemo(() => {
+    if (!expression) return [];
+    // Split by non-word characters (keeping delimiters)
+    // Identifiers start with letter/underscore and contain letters/digits/underscores
+    return expression.split(/([a-zA-Z_][a-zA-Z0-9_]*)/);
+  }, [expression]);
+
+  const identifierRegex = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+  return (
+    <>
+      {parts.map((part, index) => {
+        if (identifierRegex.test(part)) {
+          return (
+            <ReferenceLink
+              key={index}
+              symbolName={part}
+              variant="inherit"
+              sx={{ display: 'inline' }}
+            >
+              {part}
+            </ReferenceLink>
+          );
+        } else {
+          return <span key={index}>{part}</span>;
+        }
+      })}
+    </>
+  );
+};
+
+export default ExpressionText;

--- a/daedalus-dialog-editor/src/renderer/components/common/ReferenceLink.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/common/ReferenceLink.tsx
@@ -1,0 +1,50 @@
+import React, { useCallback } from 'react';
+import { Typography, TypographyProps } from '@mui/material';
+import { useNavigation } from '../../hooks/useNavigation';
+
+interface ReferenceLinkProps extends TypographyProps {
+  symbolName: string;
+  children?: React.ReactNode;
+}
+
+const ReferenceLink: React.FC<ReferenceLinkProps> = ({
+  symbolName,
+  children,
+  sx,
+  ...props
+}) => {
+  const { navigateToSymbol } = useNavigation();
+
+  const handleClick = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (!symbolName) return;
+
+    // Try to navigate
+    await navigateToSymbol(symbolName);
+  }, [navigateToSymbol, symbolName]);
+
+  return (
+    <Typography
+      component="span"
+      onClick={handleClick}
+      className="nodrag"
+      sx={{
+        cursor: 'pointer',
+        color: '#90caf9', // Light blue
+        textDecoration: 'none',
+        '&:hover': {
+          textDecoration: 'underline',
+          color: '#64b5f6',
+        },
+        display: 'inline',
+        ...sx,
+      }}
+      {...props}
+    >
+      {children || symbolName}
+    </Typography>
+  );
+};
+
+export default ReferenceLink;


### PR DESCRIPTION
Implemented clickable references in the Quest Editor graph.
- Created `ReferenceLink` component in `src/renderer/components/common/ReferenceLink.tsx` to handle symbol navigation.
- Created `ExpressionText` component in `src/renderer/components/common/ExpressionText.tsx` to parse and linkify identifiers in condition expressions.
- Updated `BaseNode` to accept `ReactNode` as label.
- Updated `DialogNode` to linkify label and NPC name.
- Updated `QuestStateNode` to linkify label and variable name.
- Updated `ConditionNode` to linkify label and expression content.

---
*PR created automatically by Jules for task [3490889585587241445](https://jules.google.com/task/3490889585587241445) started by @daniel-daga*