### PR TITLE
Fix Quest Editor infinite loop on cyclic quests and add MiniMap

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/QuestEditor/questGraphUtils.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestEditor/questGraphUtils.tsx
@@ -1,0 +1,347 @@
+import React from 'react';
+import { Node, Edge, MarkerType } from 'reactflow';
+import { Typography } from '@mui/material';
+import type { SemanticModel } from '../../types/global';
+import { getActionType } from '../actionTypes';
+
+// Helper to extract NPC from dialog or function
+export const getNpcForFunction = (funcName: string, semanticModel: SemanticModel): string | null => {
+  // Check if it's a dialog info function or condition
+  for (const dialog of Object.values(semanticModel.dialogs || {})) {
+    // Check information
+    const info = dialog.properties.information;
+    if (typeof info === 'string' && info.toLowerCase() === funcName.toLowerCase()) {
+      return (dialog.properties.npc as string) || 'Unknown';
+    }
+    if (info && typeof info === 'object' && info.name.toLowerCase() === funcName.toLowerCase()) {
+      return (dialog.properties.npc as string) || 'Unknown';
+    }
+
+    // Check condition
+    const cond = dialog.properties.condition;
+    if (typeof cond === 'string' && cond.toLowerCase() === funcName.toLowerCase()) {
+      return (dialog.properties.npc as string) || 'Unknown';
+    }
+    if (cond && typeof cond === 'object' && cond.name.toLowerCase() === funcName.toLowerCase()) {
+      return (dialog.properties.npc as string) || 'Unknown';
+    }
+  }
+  return null;
+};
+
+export interface QuestGraphData {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+export const buildQuestGraph = (semanticModel: SemanticModel, questName: string | null): QuestGraphData => {
+    if (!questName || !semanticModel) {
+        return { nodes: [], edges: [] };
+    }
+
+    const newNodes: Node[] = [];
+    const newEdges: Edge[] = [];
+    const misVarName = questName.replace('TOPIC_', 'MIS_');
+
+    // 1. Identify relevant functions/dialogs and classify them
+    interface NodeData {
+      id: string;
+      type: 'start' | 'update' | 'success' | 'failed' | 'check';
+      label: string;
+      npc: string;
+      description?: string;
+    }
+
+    const nodeDataMap = new Map<string, NodeData>();
+    // Track producers of specific variable values
+    const producersByValue = new Map<string, Set<string>>();
+
+    Object.values(semanticModel.functions || {}).forEach(func => {
+      let isRelevant = false;
+      let type: NodeData['type'] = 'check';
+      let description = '';
+
+      // Check actions
+      func.actions?.forEach(action => {
+        if ('topic' in action && action.topic === questName) {
+          isRelevant = true;
+          const actionType = getActionType(action);
+
+          if (actionType === 'createTopic') {
+              type = 'start';
+              description = 'Start Quest';
+              if (!producersByValue.has('1')) producersByValue.set('1', new Set());
+              producersByValue.get('1')?.add(func.name);
+          } else if (actionType === 'logSetTopicStatus') {
+             const status = String((action as any).status);
+             if (status.includes('SUCCESS') || status === '2') {
+                type = 'success';
+                description = 'Finish (Success)';
+                if (!producersByValue.has('2')) producersByValue.set('2', new Set());
+                producersByValue.get('2')?.add(func.name);
+             } else if (status.includes('FAILED') || status === '3') {
+                type = 'failed';
+                description = 'Finish (Failed)';
+                if (!producersByValue.has('3')) producersByValue.set('3', new Set());
+                producersByValue.get('3')?.add(func.name);
+             } else if (status.includes('RUNNING') || status === '1') {
+                type = 'update';
+                description = 'Set Running';
+                if (!producersByValue.has('1')) producersByValue.set('1', new Set());
+                producersByValue.get('1')?.add(func.name);
+             } else {
+                type = 'update';
+                description = `Set Status: ${status}`;
+             }
+          } else if (actionType === 'logEntry') {
+             if (type === 'check') type = 'update';
+             if (!description) description = 'Log Entry';
+          }
+        }
+      });
+
+      // Check conditions
+      func.conditions?.forEach(cond => {
+        if ('variableName' in cond && (cond as any).variableName === misVarName) {
+          isRelevant = true;
+        }
+      });
+
+      if (isRelevant) {
+        const npc = getNpcForFunction(func.name, semanticModel) || 'Global/Other';
+        let displayName = func.name;
+
+        for (const [dName, d] of Object.entries(semanticModel.dialogs || {})) {
+            const info = d.properties.information;
+            if ((typeof info === 'string' && info === func.name) ||
+                (typeof info === 'object' && info.name === func.name)) {
+                displayName = dName;
+                break;
+            }
+        }
+
+        nodeDataMap.set(func.name, {
+            id: func.name,
+            type,
+            label: displayName,
+            npc,
+            description
+        });
+      }
+    });
+
+    // 2. Build Dependencies
+    const adjacency = new Map<string, string[]>();
+    const incomingCount = new Map<string, number>();
+
+    nodeDataMap.forEach((_, funcName) => {
+        if (!adjacency.has(funcName)) adjacency.set(funcName, []);
+        if (!incomingCount.has(funcName)) incomingCount.set(funcName, 0);
+    });
+
+    nodeDataMap.forEach((consumerData, consumerId) => {
+        const func = semanticModel.functions[consumerId];
+        if (!func) return;
+
+        func.conditions?.forEach(cond => {
+            // A. Npc_KnowsInfo
+            if ('dialogRef' in cond) {
+                const producerDialogName = (cond as any).dialogRef;
+                const producerDialog = semanticModel.dialogs[producerDialogName];
+                if (producerDialog) {
+                    let producerFunc = null;
+                    const info = producerDialog.properties.information;
+                    if (typeof info === 'string') producerFunc = info;
+                    else if (info && typeof info === 'object') producerFunc = info.name;
+
+                    if (producerFunc && nodeDataMap.has(producerFunc)) {
+                         newEdges.push({
+                             id: `knows-${producerFunc}-${consumerId}`,
+                             source: producerFunc,
+                             target: consumerId,
+                             sourceHandle: 'out-finished',
+                             targetHandle: 'in-condition',
+                             label: 'Knows Info',
+                             type: 'smoothstep',
+                             markerEnd: { type: MarkerType.ArrowClosed },
+                             style: { stroke: '#b1b1b7', strokeWidth: 2 },
+                             labelStyle: { fill: '#b1b1b7', fontSize: 10 }
+                         });
+                         adjacency.get(producerFunc)?.push(consumerId);
+                         incomingCount.set(consumerId, (incomingCount.get(consumerId) || 0) + 1);
+                    }
+                }
+            }
+
+            // B. Variable Dependency
+            if ('variableName' in cond && (cond as any).variableName === misVarName) {
+                const op = (cond as any).operator;
+                const val = String((cond as any).value);
+                let checkVal = val;
+                if (val === 'LOG_RUNNING') checkVal = '1';
+                if (val === 'LOG_SUCCESS') checkVal = '2';
+                if (val === 'LOG_FAILED') checkVal = '3';
+
+                if (op === '==' && checkVal) {
+                    const producers = producersByValue.get(checkVal) || new Set();
+                    producers.forEach(producerId => {
+                        if (producerId !== consumerId && nodeDataMap.has(producerId)) {
+                             newEdges.push({
+                                 id: `state-${producerId}-${consumerId}`,
+                                 source: producerId,
+                                 target: consumerId,
+                                 sourceHandle: 'out-state',
+                                 targetHandle: 'in-trigger', // Logic: Producer Sets State -> Consumer Checks State
+                                 label: val,
+                                 type: 'smoothstep',
+                                 animated: true,
+                                 markerEnd: { type: MarkerType.ArrowClosed },
+                                 style: { stroke: '#2196f3', strokeWidth: 2 },
+                                 labelStyle: { fill: '#2196f3', fontSize: 10 }
+                             });
+                             adjacency.get(producerId)?.push(consumerId);
+                             incomingCount.set(consumerId, (incomingCount.get(consumerId) || 0) + 1);
+                        }
+                    });
+                }
+            }
+        });
+    });
+
+    // 3. Layout (Simplified Swimlane)
+    const npcs = Array.from(new Set(Array.from(nodeDataMap.values()).map(d => d.npc))).sort();
+    const LEVEL_WIDTH = 350;
+
+    const levels = new Map<string, number>();
+    const queue: string[] = [];
+
+    nodeDataMap.forEach((_, id) => {
+        if ((incomingCount.get(id) || 0) === 0) {
+            levels.set(id, 0);
+            queue.push(id);
+        }
+    });
+
+    // Cycle detection / limit
+    const maxLevel = nodeDataMap.size;
+
+    while (queue.length > 0) {
+        const u = queue.shift()!;
+        const currentLevel = levels.get(u)!;
+
+        // Prevent infinite processing if level exceeds possible max path (indicating cycle or very long chain)
+        if (currentLevel > maxLevel) continue;
+
+        const neighbors = adjacency.get(u) || [];
+        neighbors.forEach(v => {
+            const existingLevel = levels.get(v);
+            if (existingLevel === undefined || existingLevel < currentLevel + 1) {
+                // Fix: Check if next level would exceed max possible level to prevent infinite loop
+                if (currentLevel + 1 <= maxLevel) {
+                    levels.set(v, currentLevel + 1);
+                    queue.push(v);
+                }
+            }
+        });
+    }
+
+    // PASS 1: Calculate counts per (npc, level)
+    const laneOccupancy = new Map<string, Map<number, number>>();
+    npcs.forEach(npc => laneOccupancy.set(npc, new Map()));
+
+    nodeDataMap.forEach((data, id) => {
+        const level = levels.get(id) || 0;
+        const npcMap = laneOccupancy.get(data.npc)!;
+        const count = npcMap.get(level) || 0;
+        npcMap.set(level, count + 1);
+    });
+
+    // PASS 2: Calculate Lane Heights and Y Offsets
+    const NPC_LANE_HEIGHT = new Map<string, number>();
+    const NPC_Y_START = new Map<string, number>();
+    let currentY = 0;
+    const NODE_VERTICAL_SPACING = 250;
+    const MIN_LANE_HEIGHT = 300;
+    const LANE_PADDING = 50;
+
+    npcs.forEach(npc => {
+        NPC_Y_START.set(npc, currentY);
+
+        const npcMap = laneOccupancy.get(npc)!;
+        let maxNodesInCol = 0;
+        if (npcMap.size > 0) {
+             maxNodesInCol = Math.max(...Array.from(npcMap.values()));
+        }
+
+        const requiredHeight = Math.max(
+            (maxNodesInCol * NODE_VERTICAL_SPACING) + LANE_PADDING,
+            MIN_LANE_HEIGHT
+        );
+        NPC_LANE_HEIGHT.set(npc, requiredHeight);
+        currentY += requiredHeight;
+    });
+
+    // PASS 3: Create Nodes
+    const currentCounts = new Map<string, Map<number, number>>();
+    npcs.forEach(npc => currentCounts.set(npc, new Map()));
+
+    nodeDataMap.forEach((data, id) => {
+        const level = levels.get(id) || 0;
+        const npcMap = currentCounts.get(data.npc)!;
+        const count = npcMap.get(level) || 0;
+        npcMap.set(level, count + 1);
+
+        const x = level * LEVEL_WIDTH + 50;
+        const yBase = NPC_Y_START.get(data.npc)!;
+        const yOffset = count * NODE_VERTICAL_SPACING;
+
+        const y = yBase + 50 + yOffset;
+
+        // Determine node type
+        let nodeType = 'dialog';
+        if (data.type === 'start' || data.type === 'success' || data.type === 'failed' || data.description?.includes('Status')) {
+             nodeType = 'questState';
+        }
+
+        newNodes.push({
+            id,
+            position: { x, y },
+            type: nodeType,
+            data: {
+                label: data.label,
+                npc: data.npc,
+                description: data.description,
+                type: data.type,
+                status: data.description, // rough mapping
+                variableName: misVarName
+            },
+        });
+    });
+
+    // Swimlanes
+    npcs.forEach((npc) => {
+        const maxLevelVal = Math.max(...Array.from(levels.values()), 0);
+        const y = NPC_Y_START.get(npc)!;
+        const height = NPC_LANE_HEIGHT.get(npc)!;
+
+        newNodes.unshift({
+            id: `swimlane-${npc}`,
+            type: 'group',
+            position: { x: 0, y },
+            style: {
+                width: (maxLevelVal + 1) * LEVEL_WIDTH + 200,
+                height: height - 20,
+                backgroundColor: 'rgba(255, 255, 255, 0.02)', // Very subtle light
+                border: '1px dashed #444',
+                zIndex: -1,
+                padding: 10,
+                color: '#666'
+            },
+            data: { label: <Typography variant="subtitle2" sx={{ opacity: 0.5 }}>{npc}</Typography> },
+            selectable: false,
+            draggable: false,
+        });
+    });
+
+    return { nodes: newNodes, edges: newEdges };
+};

--- a/daedalus-dialog-editor/src/renderer/components/QuestFlow.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestFlow.tsx
@@ -1,10 +1,10 @@
-import React, { useMemo, useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import ReactFlow, {
   Background,
   Controls,
+  MiniMap,
   Node,
   Edge,
-  MarkerType,
   useNodesState,
   useEdgesState,
   addEdge,
@@ -14,8 +14,8 @@ import ReactFlow, {
 import 'reactflow/dist/style.css';
 import { Box, Typography } from '@mui/material';
 import type { SemanticModel } from '../types/global';
-import { getActionType } from './actionTypes';
 import { useNavigation } from '../hooks/useNavigation';
+import { buildQuestGraph } from './QuestEditor/questGraphUtils';
 
 import DialogNode from './QuestEditor/Nodes/DialogNode';
 import QuestStateNode from './QuestEditor/Nodes/QuestStateNode';
@@ -31,31 +31,6 @@ const nodeTypes: NodeTypes = {
   dialog: DialogNode,
   questState: QuestStateNode,
   condition: ConditionNode,
-};
-
-// Helper to extract NPC from dialog or function
-const getNpcForFunction = (funcName: string, semanticModel: SemanticModel): string | null => {
-  // Check if it's a dialog info function or condition
-  for (const dialog of Object.values(semanticModel.dialogs || {})) {
-    // Check information
-    const info = dialog.properties.information;
-    if (typeof info === 'string' && info.toLowerCase() === funcName.toLowerCase()) {
-      return (dialog.properties.npc as string) || 'Unknown';
-    }
-    if (info && typeof info === 'object' && info.name.toLowerCase() === funcName.toLowerCase()) {
-      return (dialog.properties.npc as string) || 'Unknown';
-    }
-
-    // Check condition
-    const cond = dialog.properties.condition;
-    if (typeof cond === 'string' && cond.toLowerCase() === funcName.toLowerCase()) {
-      return (dialog.properties.npc as string) || 'Unknown';
-    }
-    if (cond && typeof cond === 'object' && cond.name.toLowerCase() === funcName.toLowerCase()) {
-      return (dialog.properties.npc as string) || 'Unknown';
-    }
-  }
-  return null;
 };
 
 const QuestFlow: React.FC<QuestFlowProps> = ({ semanticModel, questName }) => {
@@ -94,312 +69,12 @@ const QuestFlow: React.FC<QuestFlowProps> = ({ semanticModel, questName }) => {
     setEdges((eds) => addEdge({ ...params, type: 'smoothstep', style: { stroke: '#fff', strokeWidth: 2 } }, eds));
   }, [setEdges]);
 
-  // Initialize Graph from Semantic Model
+  // Initialize Graph from Semantic Model using the utility function
   useEffect(() => {
-    if (!questName || !semanticModel) {
-        setNodes([]);
-        setEdges([]);
-        return;
-    }
-
-    const newNodes: Node[] = [];
-    const newEdges: Edge[] = [];
-    const misVarName = questName.replace('TOPIC_', 'MIS_');
-
-    // 1. Identify relevant functions/dialogs and classify them
-    interface NodeData {
-      id: string;
-      type: 'start' | 'update' | 'success' | 'failed' | 'check';
-      label: string;
-      npc: string;
-      description?: string;
-    }
-
-    const nodeDataMap = new Map<string, NodeData>();
-    // Track producers of specific variable values
-    const producersByValue = new Map<string, Set<string>>();
-
-    Object.values(semanticModel.functions || {}).forEach(func => {
-      let isRelevant = false;
-      let type: NodeData['type'] = 'check';
-      let description = '';
-
-      // Check actions
-      func.actions?.forEach(action => {
-        if ('topic' in action && action.topic === questName) {
-          isRelevant = true;
-          const actionType = getActionType(action);
-
-          if (actionType === 'createTopic') {
-              type = 'start';
-              description = 'Start Quest';
-              if (!producersByValue.has('1')) producersByValue.set('1', new Set());
-              producersByValue.get('1')?.add(func.name);
-          } else if (actionType === 'logSetTopicStatus') {
-             const status = String((action as any).status);
-             if (status.includes('SUCCESS') || status === '2') {
-                type = 'success';
-                description = 'Finish (Success)';
-                if (!producersByValue.has('2')) producersByValue.set('2', new Set());
-                producersByValue.get('2')?.add(func.name);
-             } else if (status.includes('FAILED') || status === '3') {
-                type = 'failed';
-                description = 'Finish (Failed)';
-                if (!producersByValue.has('3')) producersByValue.set('3', new Set());
-                producersByValue.get('3')?.add(func.name);
-             } else if (status.includes('RUNNING') || status === '1') {
-                type = 'update';
-                description = 'Set Running';
-                if (!producersByValue.has('1')) producersByValue.set('1', new Set());
-                producersByValue.get('1')?.add(func.name);
-             } else {
-                type = 'update';
-                description = `Set Status: ${status}`;
-             }
-          } else if (actionType === 'logEntry') {
-             if (type === 'check') type = 'update';
-             if (!description) description = 'Log Entry';
-          }
-        }
-      });
-
-      // Check conditions
-      func.conditions?.forEach(cond => {
-        if ('variableName' in cond && (cond as any).variableName === misVarName) {
-          isRelevant = true;
-        }
-      });
-
-      if (isRelevant) {
-        const npc = getNpcForFunction(func.name, semanticModel) || 'Global/Other';
-        let displayName = func.name;
-
-        for (const [dName, d] of Object.entries(semanticModel.dialogs || {})) {
-            const info = d.properties.information;
-            if ((typeof info === 'string' && info === func.name) ||
-                (typeof info === 'object' && info.name === func.name)) {
-                displayName = dName;
-                break;
-            }
-        }
-
-        nodeDataMap.set(func.name, {
-            id: func.name,
-            type,
-            label: displayName,
-            npc,
-            description
-        });
-      }
-    });
-
-    // 2. Build Dependencies
-    const adjacency = new Map<string, string[]>();
-    const incomingCount = new Map<string, number>();
-
-    nodeDataMap.forEach((_, funcName) => {
-        if (!adjacency.has(funcName)) adjacency.set(funcName, []);
-        if (!incomingCount.has(funcName)) incomingCount.set(funcName, 0);
-    });
-
-    nodeDataMap.forEach((consumerData, consumerId) => {
-        const func = semanticModel.functions[consumerId];
-        if (!func) return;
-
-        func.conditions?.forEach(cond => {
-            // A. Npc_KnowsInfo
-            if ('dialogRef' in cond) {
-                const producerDialogName = (cond as any).dialogRef;
-                const producerDialog = semanticModel.dialogs[producerDialogName];
-                if (producerDialog) {
-                    let producerFunc = null;
-                    const info = producerDialog.properties.information;
-                    if (typeof info === 'string') producerFunc = info;
-                    else if (info && typeof info === 'object') producerFunc = info.name;
-
-                    if (producerFunc && nodeDataMap.has(producerFunc)) {
-                         newEdges.push({
-                             id: `knows-${producerFunc}-${consumerId}`,
-                             source: producerFunc,
-                             target: consumerId,
-                             sourceHandle: 'out-finished',
-                             targetHandle: 'in-condition',
-                             label: 'Knows Info',
-                             type: 'smoothstep',
-                             markerEnd: { type: MarkerType.ArrowClosed },
-                             style: { stroke: '#b1b1b7', strokeWidth: 2 },
-                             labelStyle: { fill: '#b1b1b7', fontSize: 10 }
-                         });
-                         adjacency.get(producerFunc)?.push(consumerId);
-                         incomingCount.set(consumerId, (incomingCount.get(consumerId) || 0) + 1);
-                    }
-                }
-            }
-
-            // B. Variable Dependency
-            if ('variableName' in cond && (cond as any).variableName === misVarName) {
-                const op = (cond as any).operator;
-                const val = String((cond as any).value);
-                let checkVal = val;
-                if (val === 'LOG_RUNNING') checkVal = '1';
-                if (val === 'LOG_SUCCESS') checkVal = '2';
-                if (val === 'LOG_FAILED') checkVal = '3';
-
-                if (op === '==' && checkVal) {
-                    const producers = producersByValue.get(checkVal) || new Set();
-                    producers.forEach(producerId => {
-                        if (producerId !== consumerId && nodeDataMap.has(producerId)) {
-                             newEdges.push({
-                                 id: `state-${producerId}-${consumerId}`,
-                                 source: producerId,
-                                 target: consumerId,
-                                 sourceHandle: 'out-state',
-                                 targetHandle: 'in-trigger', // Logic: Producer Sets State -> Consumer Checks State
-                                 label: val,
-                                 type: 'smoothstep',
-                                 animated: true,
-                                 markerEnd: { type: MarkerType.ArrowClosed },
-                                 style: { stroke: '#2196f3', strokeWidth: 2 },
-                                 labelStyle: { fill: '#2196f3', fontSize: 10 }
-                             });
-                             adjacency.get(producerId)?.push(consumerId);
-                             incomingCount.set(consumerId, (incomingCount.get(consumerId) || 0) + 1);
-                        }
-                    });
-                }
-            }
-        });
-    });
-
-    // 3. Layout (Simplified Swimlane)
-    const npcs = Array.from(new Set(Array.from(nodeDataMap.values()).map(d => d.npc))).sort();
-    const LEVEL_WIDTH = 350;
-
-    const levels = new Map<string, number>();
-    const queue: string[] = [];
-
-    nodeDataMap.forEach((_, id) => {
-        if ((incomingCount.get(id) || 0) === 0) {
-            levels.set(id, 0);
-            queue.push(id);
-        }
-    });
-
-    while (queue.length > 0) {
-        const u = queue.shift()!;
-        const currentLevel = levels.get(u)!;
-        const neighbors = adjacency.get(u) || [];
-        neighbors.forEach(v => {
-            const existingLevel = levels.get(v);
-            if (existingLevel === undefined || existingLevel < currentLevel + 1) {
-                levels.set(v, currentLevel + 1);
-                queue.push(v);
-            }
-        });
-    }
-
-    // PASS 1: Calculate counts per (npc, level)
-    const laneOccupancy = new Map<string, Map<number, number>>();
-    npcs.forEach(npc => laneOccupancy.set(npc, new Map()));
-
-    nodeDataMap.forEach((data, id) => {
-        const level = levels.get(id) || 0;
-        const npcMap = laneOccupancy.get(data.npc)!;
-        const count = npcMap.get(level) || 0;
-        npcMap.set(level, count + 1);
-    });
-
-    // PASS 2: Calculate Lane Heights and Y Offsets
-    const NPC_LANE_HEIGHT = new Map<string, number>();
-    const NPC_Y_START = new Map<string, number>();
-    let currentY = 0;
-    const NODE_VERTICAL_SPACING = 250;
-    const MIN_LANE_HEIGHT = 300;
-    const LANE_PADDING = 50;
-
-    npcs.forEach(npc => {
-        NPC_Y_START.set(npc, currentY);
-
-        const npcMap = laneOccupancy.get(npc)!;
-        let maxNodesInCol = 0;
-        if (npcMap.size > 0) {
-             maxNodesInCol = Math.max(...Array.from(npcMap.values()));
-        }
-
-        const requiredHeight = Math.max(
-            (maxNodesInCol * NODE_VERTICAL_SPACING) + LANE_PADDING,
-            MIN_LANE_HEIGHT
-        );
-        NPC_LANE_HEIGHT.set(npc, requiredHeight);
-        currentY += requiredHeight;
-    });
-
-    // PASS 3: Create Nodes
-    const currentCounts = new Map<string, Map<number, number>>();
-    npcs.forEach(npc => currentCounts.set(npc, new Map()));
-
-    nodeDataMap.forEach((data, id) => {
-        const level = levels.get(id) || 0;
-        const npcMap = currentCounts.get(data.npc)!;
-        const count = npcMap.get(level) || 0;
-        npcMap.set(level, count + 1);
-
-        const x = level * LEVEL_WIDTH + 50;
-        const yBase = NPC_Y_START.get(data.npc)!;
-        const yOffset = count * NODE_VERTICAL_SPACING;
-
-        const y = yBase + 50 + yOffset;
-
-        // Determine node type
-        let nodeType = 'dialog';
-        if (data.type === 'start' || data.type === 'success' || data.type === 'failed' || data.description?.includes('Status')) {
-             nodeType = 'questState';
-        }
-
-        newNodes.push({
-            id,
-            position: { x, y },
-            type: nodeType,
-            data: {
-                label: data.label,
-                npc: data.npc,
-                description: data.description,
-                type: data.type,
-                status: data.description, // rough mapping
-                variableName: misVarName
-            },
-        });
-    });
-
-    // Swimlanes
-    npcs.forEach((npc) => {
-        const maxLevel = Math.max(...Array.from(levels.values()), 0);
-        const y = NPC_Y_START.get(npc)!;
-        const height = NPC_LANE_HEIGHT.get(npc)!;
-
-        newNodes.unshift({
-            id: `swimlane-${npc}`,
-            type: 'group',
-            position: { x: 0, y },
-            style: {
-                width: (maxLevel + 1) * LEVEL_WIDTH + 200,
-                height: height - 20,
-                backgroundColor: 'rgba(255, 255, 255, 0.02)', // Very subtle light
-                border: '1px dashed #444',
-                zIndex: -1,
-                padding: 10,
-                color: '#666'
-            },
-            data: { label: <Typography variant="subtitle2" sx={{ opacity: 0.5 }}>{npc}</Typography> },
-            selectable: false,
-            draggable: false,
-        });
-    });
-
+    const { nodes: newNodes, edges: newEdges } = buildQuestGraph(semanticModel, questName);
     setNodes(newNodes);
     setEdges(newEdges);
-
-  }, [semanticModel, questName, setNodes, setEdges]); // Runs when model/quest changes
+  }, [semanticModel, questName, setNodes, setEdges]);
 
   if (!questName) {
       return (
@@ -423,6 +98,20 @@ const QuestFlow: React.FC<QuestFlowProps> = ({ semanticModel, questName }) => {
       >
         <Background color="#333" gap={20} />
         <Controls />
+        <MiniMap
+            nodeStrokeColor={(n) => {
+                if (n.type === 'questState') return '#00ff00';
+                if (n.type === 'group') return '#eee';
+                return '#0041d0';
+            }}
+            nodeColor={(n) => {
+                if (n.type === 'group') return '#fff';
+                return '#fff';
+            }}
+            nodeBorderRadius={2}
+            maskColor="rgba(0, 0, 0, 0.7)"
+            style={{ backgroundColor: '#222' }}
+        />
       </ReactFlow>
     </Box>
   );

--- a/daedalus-dialog-editor/tests/questGraphUtils.test.tsx
+++ b/daedalus-dialog-editor/tests/questGraphUtils.test.tsx
@@ -1,0 +1,120 @@
+import { buildQuestGraph } from '../src/renderer/components/QuestEditor/questGraphUtils';
+import type { SemanticModel } from '../src/renderer/types/global';
+
+// Mock Semantic Model Helper
+const createMockModel = (functions: any[], dialogs: any[]): SemanticModel => {
+    const funcMap: Record<string, any> = {};
+    functions.forEach(f => funcMap[f.name] = f);
+
+    const dialogMap: Record<string, any> = {};
+    dialogs.forEach(d => dialogMap[d.name] = d);
+
+    return {
+        functions: funcMap,
+        dialogs: dialogMap,
+        variables: {},
+        constants: {},
+        instances: {},
+        classes: {},
+        structs: {},
+    } as SemanticModel;
+};
+
+describe('questGraphUtils', () => {
+    it('should handle cyclic dependencies gracefully', () => {
+        const questName = 'TOPIC_TEST';
+        const misVarName = 'MIS_TEST';
+
+        // Cycle: A -> B -> A
+        // A runs when MIS_TEST == 1, sets MIS_TEST = 2
+        // B runs when MIS_TEST == 2, sets MIS_TEST = 1
+
+        const functions = [
+            {
+                name: 'DIA_A_Info',
+                conditions: [
+                    { variableName: misVarName, operator: '==', value: 1 } // Consumes 1
+                ],
+                actions: [
+                    { topic: questName, status: 'LOG_SUCCESS' } // Produces 2 (SUCCESS)
+                ]
+            },
+            {
+                name: 'DIA_B_Info',
+                conditions: [
+                    { variableName: misVarName, operator: '==', value: 2 } // Consumes 2
+                ],
+                actions: [
+                    { topic: questName, status: 'LOG_RUNNING' } // Produces 1 (RUNNING) - Cycle!
+                ]
+            },
+            // Starter to inject initial state 1
+            {
+                name: 'DIA_Start_Info',
+                actions: [
+                    { topic: questName, topicType: 'LOG_MISSION' } // Produces 1 (implicit start)
+                ]
+            }
+        ];
+
+        const dialogs = [
+            { name: 'DIA_A', properties: { information: 'DIA_A_Info', npc: 'NPC_A' } },
+            { name: 'DIA_B', properties: { information: 'DIA_B_Info', npc: 'NPC_B' } },
+            { name: 'DIA_Start', properties: { information: 'DIA_Start_Info', npc: 'NPC_Start' } },
+        ];
+
+        const model = createMockModel(functions, dialogs);
+
+        // This call should not hang
+        const { nodes, edges } = buildQuestGraph(model, questName);
+
+        // Verify nodes are created
+        expect(nodes.length).toBeGreaterThan(0);
+
+        // Verify we have edges representing the cycle
+        // A -> B (state 2)
+        // B -> A (state 1)
+        // Start -> A (state 1)
+        expect(edges.length).toBeGreaterThanOrEqual(3);
+
+        const edgeAtoB = edges.find(e => e.source === 'DIA_A_Info' && e.target === 'DIA_B_Info');
+        const edgeBtoA = edges.find(e => e.source === 'DIA_B_Info' && e.target === 'DIA_A_Info');
+
+        expect(edgeAtoB).toBeDefined();
+        expect(edgeBtoA).toBeDefined();
+    });
+
+    it('should build a simple DAG correctly', () => {
+         const questName = 'TOPIC_SIMPLE';
+         const misVarName = 'MIS_SIMPLE';
+
+         const functions = [
+             {
+                 name: 'DIA_Start_Info',
+                 actions: [
+                     { topic: questName, topicType: 'LOG_MISSION' } // Produces 1
+                 ]
+             },
+             {
+                 name: 'DIA_End_Info',
+                 conditions: [
+                     { variableName: misVarName, operator: '==', value: 1 } // Consumes 1
+                 ],
+                 actions: [
+                     { topic: questName, status: 'LOG_SUCCESS' } // Produces 2
+                 ]
+             }
+         ];
+
+         const dialogs = [
+             { name: 'DIA_Start', properties: { information: 'DIA_Start_Info', npc: 'NPC_Start' } },
+             { name: 'DIA_End', properties: { information: 'DIA_End_Info', npc: 'NPC_End' } },
+         ];
+
+         const model = createMockModel(functions, dialogs);
+         const { nodes, edges } = buildQuestGraph(model, questName);
+
+         expect(nodes).toHaveLength(4); // 2 nodes + 2 swimlanes
+         expect(edges).toHaveLength(1); // Start -> End
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.11.0
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
+      '@monaco-editor/react':
+        specifier: ^4.6.0
+        version: 4.7.0(monaco-editor@0.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/icons-material':
         specifier: ^5.18.0
         version: 5.18.0(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
@@ -65,9 +68,6 @@ importers:
       '@jest/globals':
         specifier: ^30.2.0
         version: 30.2.0
-      '@monaco-editor/react':
-        specifier: ^4.6.0
-        version: 4.7.0(monaco-editor@0.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@playwright/test':
         specifier: ^1.56.1
         version: 1.58.1


### PR DESCRIPTION
Refactored quest graph layout logic to `questGraphUtils.tsx` and added cycle detection to prevent infinite loops (DoS) when visualizing quests with circular dependencies. Added a MiniMap to the Quest Flow editor for better navigation.

---
*PR created automatically by Jules for task [15815179094423754245](https://jules.google.com/task/15815179094423754245) started by @daniel-daga*