### PR TITLE
Improve Dialog Editor Diary/Mission Lines & Topic Autocomplete

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/ConditionCard.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/ConditionCard.tsx
@@ -174,7 +174,7 @@ const ConditionCard = React.memo(React.forwardRef<HTMLInputElement, ConditionCar
               onChange={(value) => handleUpdate({ ...localCondition, variableName: value })}
               onFlush={flushUpdate}
               typeFilter={['int', 'string', 'float']}
-              namePrefix="MIS_"
+              namePrefix={['MIS_', 'Check_']}
               isMainField
               mainFieldRef={mainFieldRef}
               sx={{ flex: 1 }}

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/CreateTopicRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/CreateTopicRenderer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TextField, MenuItem } from '@mui/material';
 import type { BaseActionRendererProps } from './types';
 import { ActionFieldContainer, ActionDeleteButton } from '../common';
 import VariableAutocomplete from '../common/VariableAutocomplete';
@@ -27,17 +28,19 @@ const CreateTopicRenderer: React.FC<BaseActionRendererProps> = ({
         namePrefix="TOPIC_"
         semanticModel={semanticModel}
       />
-      <VariableAutocomplete
+      <TextField
+        select
         fullWidth
         label="Topic Type"
-        value={action.topicType || ''}
-        onChange={(value) => handleUpdate({ ...action, topicType: value })}
-        onFlush={flushUpdate}
+        value={action.topicType || 'LOG_MISSION'}
+        onChange={(e) => handleUpdate({ ...action, topicType: e.target.value })}
+        onBlur={flushUpdate}
         onKeyDown={handleKeyDown}
-        typeFilter="int"
-        namePrefix="LOG_"
-        semanticModel={semanticModel}
-      />
+        size="small"
+      >
+        <MenuItem value="LOG_MISSION">LOG_MISSION</MenuItem>
+        <MenuItem value="LOG_NOTE">LOG_NOTE</MenuItem>
+      </TextField>
       <ActionDeleteButton onClick={handleDelete} />
     </ActionFieldContainer>
   );

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/LogEntryRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/LogEntryRenderer.tsx
@@ -34,6 +34,8 @@ const LogEntryRenderer: React.FC<BaseActionRendererProps> = ({
         onKeyDown={handleKeyDown}
         isMainField
         mainFieldRef={mainFieldRef}
+        multiline
+        rows={2}
       />
       <ActionDeleteButton onClick={handleDelete} />
     </ActionFieldContainer>

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/LogSetTopicStatusRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/LogSetTopicStatusRenderer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TextField, MenuItem, Box, Chip } from '@mui/material';
 import type { BaseActionRendererProps } from './types';
 import { ActionFieldContainer, ActionDeleteButton } from '../common';
 import VariableAutocomplete from '../common/VariableAutocomplete';
@@ -12,6 +13,17 @@ const LogSetTopicStatusRenderer: React.FC<BaseActionRendererProps> = ({
   mainFieldRef,
   semanticModel
 }) => {
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'LOG_RUNNING': return 'info';
+      case 'LOG_SUCCESS': return 'success';
+      case 'LOG_FAILED': return 'error';
+      case 'LOG_OBSOLETE': return 'default';
+      default: return 'default';
+    }
+  };
+
   return (
     <ActionFieldContainer>
       <VariableAutocomplete
@@ -27,17 +39,30 @@ const LogSetTopicStatusRenderer: React.FC<BaseActionRendererProps> = ({
         namePrefix="TOPIC_"
         semanticModel={semanticModel}
       />
-      <VariableAutocomplete
+      <TextField
+        select
         fullWidth
         label="Status"
-        value={action.status || ''}
-        onChange={(value) => handleUpdate({ ...action, status: value })}
-        onFlush={flushUpdate}
+        value={action.status || 'LOG_RUNNING'}
+        onChange={(e) => handleUpdate({ ...action, status: e.target.value })}
+        onBlur={flushUpdate}
         onKeyDown={handleKeyDown}
-        typeFilter="int"
-        namePrefix="LOG_"
-        semanticModel={semanticModel}
-      />
+        size="small"
+      >
+        {['LOG_RUNNING', 'LOG_SUCCESS', 'LOG_FAILED', 'LOG_OBSOLETE'].map((status) => (
+          <MenuItem key={status} value={status}>
+             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Chip
+                label={status}
+                size="small"
+                color={getStatusColor(status) as any}
+                variant="outlined"
+                sx={{ height: 20, fontSize: '0.7rem', cursor: 'pointer' }}
+              />
+            </Box>
+          </MenuItem>
+        ))}
+      </TextField>
       <ActionDeleteButton onClick={handleDelete} />
     </ActionFieldContainer>
   );

--- a/daedalus-dialog-editor/src/renderer/components/common/VariableAutocomplete.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/common/VariableAutocomplete.tsx
@@ -60,7 +60,9 @@ type OptionType = {
   value?: string | number | boolean;
 };
 
-const filter = createFilterOptions<OptionType>();
+const filter = createFilterOptions<OptionType>({
+  stringify: (option) => `${option.name} ${option.type} ${option.value !== undefined ? option.value : ''}`
+});
 
 const VariableAutocomplete = React.memo<VariableAutocompleteProps>(({
   value,


### PR DESCRIPTION
Improved the UI and UX for diary and mission related dialog lines.
1. `CreateTopic` action now uses a dropdown for Topic Type (Mission/Note).
2. `LogSetTopicStatus` action now uses a dropdown for Status (Running/Success/Failed/Obsolete) with color-coded chips.
3. `LogEntry` action text field is now multiline for better editing of long texts.
4. `VariableAutocomplete` now searches in constant values, allowing users to find topics by their string content (e.g. searching "My Quest" finds `TOPIC_MyQuest`).
5. `ConditionCard` variable condition now suggests variables starting with `Check_` in addition to `MIS_`.

---
*PR created automatically by Jules for task [4979228547519901625](https://jules.google.com/task/4979228547519901625) started by @daniel-daga*