### PR TITLE
Improve quest management UX with analysis and editing

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/QuestDetails.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestDetails.tsx
@@ -1,9 +1,35 @@
-import React, { useMemo } from 'react';
-import { Box, Typography, Paper, Chip, Stack, List, ListItem, ListItemText, Divider, IconButton, Tooltip } from '@mui/material';
-import { OpenInNew as OpenInNewIcon } from '@mui/icons-material';
+import React, { useMemo, useState, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  Chip,
+  Stack,
+  List,
+  ListItem,
+  ListItemText,
+  Divider,
+  IconButton,
+  Tooltip,
+  Button,
+  TextField,
+  CircularProgress
+} from '@mui/material';
+import {
+  OpenInNew as OpenInNewIcon,
+  Add as AddIcon,
+  Edit as EditIcon,
+  Save as SaveIcon,
+  Cancel as CancelIcon,
+  CheckCircle as CheckCircleIcon,
+  Warning as WarningIcon,
+  Info as InfoIcon
+} from '@mui/icons-material';
 import type { SemanticModel } from '../types/global';
 import { getActionType } from './actionTypes';
 import { useNavigation } from '../hooks/useNavigation';
+import { analyzeQuest } from './QuestEditor/questGraphUtils';
+import { useProjectStore } from '../store/projectStore';
 
 interface QuestDetailsProps {
   semanticModel: SemanticModel;
@@ -20,6 +46,20 @@ interface QuestReference {
 
 const QuestDetails: React.FC<QuestDetailsProps> = ({ semanticModel, questName }) => {
   const { navigateToDialog, navigateToSymbol } = useNavigation();
+  const { addVariable, updateGlobalConstant, isLoading } = useProjectStore();
+
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [editTitle, setEditTitle] = useState('');
+
+  // Reset editing state when quest changes
+  useEffect(() => {
+      setIsEditingTitle(false);
+      setEditTitle('');
+  }, [questName]);
+
+  const analysis = useMemo(() => {
+    return questName ? analyzeQuest(semanticModel, questName) : null;
+  }, [semanticModel, questName]);
 
   const references = useMemo(() => {
     if (!questName) return [];
@@ -93,6 +133,25 @@ const QuestDetails: React.FC<QuestDetailsProps> = ({ semanticModel, questName })
     return refs;
   }, [semanticModel, questName]);
 
+  const handleCreateVariable = async () => {
+      if (!analysis || analysis.misVariableExists || !analysis.misVariableName) return;
+
+      // Use topic file path if available, or just throw error/ask user (not implemented here)
+      const filePath = analysis.filePaths.topic;
+      if (filePath) {
+           await addVariable(analysis.misVariableName, 'int', undefined, filePath, false);
+      } else {
+          // Should normally allow picking file, but for now we rely on topic file being present
+          console.error("Cannot determine file path for new variable");
+      }
+  };
+
+  const handleSaveTitle = async () => {
+      if (!analysis || !analysis.filePaths.topic || !questName) return;
+      await updateGlobalConstant(questName, editTitle, analysis.filePaths.topic);
+      setIsEditingTitle(false);
+  };
+
   if (!questName) {
     return (
       <Box sx={{ p: 3, display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
@@ -101,34 +160,80 @@ const QuestDetails: React.FC<QuestDetailsProps> = ({ semanticModel, questName })
     );
   }
 
-  const questConstant = semanticModel.constants?.[questName];
-  const misVarName = questName.replace('TOPIC_', 'MIS_');
-  const misVariable = semanticModel.variables?.[misVarName];
-
   return (
     <Box sx={{ p: 3, height: '100%', overflow: 'auto' }}>
-      <Typography variant="h4" gutterBottom>
-        {String(questConstant?.value || questName).replace(/^"|"$/g, '')}
-      </Typography>
+      <Box sx={{ mb: 2 }}>
+          {isEditingTitle ? (
+              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                  <TextField
+                      value={editTitle}
+                      onChange={(e) => setEditTitle(e.target.value)}
+                      fullWidth
+                      autoFocus
+                      size="small"
+                      placeholder="Quest Title"
+                  />
+                  <IconButton onClick={handleSaveTitle} color="primary" disabled={isLoading}>
+                      {isLoading ? <CircularProgress size={24} /> : <SaveIcon />}
+                  </IconButton>
+                  <IconButton onClick={() => setIsEditingTitle(false)} disabled={isLoading}><CancelIcon /></IconButton>
+              </Box>
+          ) : (
+             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Typography variant="h4" sx={{ flexGrow: 1, wordBreak: 'break-word' }}>
+                    {analysis?.description || questName}
+                </Typography>
+                <Tooltip title="Edit Description">
+                    <IconButton onClick={() => {
+                        setEditTitle(analysis?.description || '');
+                        setIsEditingTitle(true);
+                    }}>
+                        <EditIcon />
+                    </IconButton>
+                </Tooltip>
+             </Box>
+          )}
+      </Box>
 
-      <Stack direction="row" spacing={1} sx={{ mb: 3 }}>
+      <Stack direction="row" spacing={1} sx={{ mb: 3, flexWrap: 'wrap', gap: 1 }}>
         <Chip 
           label={questName} 
           variant="outlined" 
           onDelete={() => navigateToSymbol(questName, { preferSource: true })}
           deleteIcon={<Tooltip title="Follow reference"><OpenInNewIcon /></Tooltip>}
         />
-        {misVariable ? (
+
+        {analysis?.misVariableExists ? (
             <Chip 
-              label={`Var: ${misVarName}`} 
+              label={`Var: ${analysis.misVariableName}`}
               color="success" 
               variant="outlined" 
-              onDelete={() => navigateToSymbol(misVarName, { preferSource: true })}
+              onDelete={() => navigateToSymbol(analysis.misVariableName, { preferSource: true })}
               deleteIcon={<Tooltip title="Follow reference"><OpenInNewIcon /></Tooltip>}
             />
         ) : (
-            <Chip label={`Missing Var: ${misVarName}`} color="warning" variant="outlined" />
+            <Chip
+                label={`Missing Var: ${analysis?.misVariableName || 'MIS_...'}`}
+                color="warning"
+                variant="outlined"
+                onDelete={handleCreateVariable}
+                deleteIcon={<Tooltip title="Create Variable"><AddIcon /></Tooltip>}
+                disabled={isLoading}
+            />
         )}
+
+        <Chip
+            label={analysis?.status === 'implemented' ? 'Implemented' :
+                   analysis?.status === 'wip' ? 'Work In Progress' :
+                   analysis?.status === 'broken' ? 'Broken' : 'Not Started'}
+            color={analysis?.status === 'implemented' ? 'success' :
+                   analysis?.status === 'wip' ? 'info' :
+                   analysis?.status === 'broken' ? 'error' : 'default'}
+            icon={analysis?.status === 'implemented' ? <CheckCircleIcon /> :
+                  analysis?.status === 'wip' ? <InfoIcon /> :
+                  analysis?.status === 'broken' ? <WarningIcon /> : undefined}
+            variant="filled"
+        />
       </Stack>
 
       <Paper sx={{ p: 2, mb: 3 }}>

--- a/daedalus-dialog-editor/src/renderer/components/QuestList.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestList.tsx
@@ -12,12 +12,27 @@ import {
   ToggleButton,
   ToggleButtonGroup,
   IconButton,
-  Tooltip
+  Tooltip,
+  ListItemIcon,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel
 } from '@mui/material';
-import { Search as SearchIcon, Add as AddIcon, OpenInNew as OpenInNewIcon } from '@mui/icons-material';
+import {
+  Search as SearchIcon,
+  Add as AddIcon,
+  OpenInNew as OpenInNewIcon,
+  Check as CheckIcon,
+  Build as BuildIcon,
+  Report as ReportIcon,
+  HourglassEmpty as HourglassEmptyIcon,
+  FilterList as FilterListIcon
+} from '@mui/icons-material';
 import type { SemanticModel } from '../types/global';
 import CreateQuestDialog from './CreateQuestDialog';
 import { useNavigation } from '../hooks/useNavigation';
+import { analyzeQuest } from './QuestEditor/questGraphUtils';
 
 interface QuestListProps {
   semanticModel: SemanticModel;
@@ -29,6 +44,7 @@ const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onS
   const { navigateToSymbol } = useNavigation();
   const [filter, setFilter] = useState('');
   const [viewMode, setViewMode] = useState<'all' | 'used'>('all');
+  const [statusFilter, setStatusFilter] = useState<'all' | 'broken' | 'wip' | 'implemented' | 'not_started'>('all');
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
 
   // Memoize the list of all TOPIC_ constants
@@ -36,6 +52,17 @@ const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onS
     const constants = semanticModel.constants || {};
     return Object.values(constants).filter(c => c.name.startsWith('TOPIC_'));
   }, [semanticModel.constants]);
+
+  // Analyze all quests once when model changes
+  const questAnalysisMap = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof analyzeQuest>>();
+    // To avoid blocking UI on large projects, we could debounce this or use a worker
+    // But for now, we assume it's fast enough or React scheduling handles it
+    quests.forEach(q => {
+        map.set(q.name, analyzeQuest(semanticModel, q.name));
+    });
+    return map;
+  }, [quests, semanticModel]);
 
   // Memoize the set of used topics to enable "Used" filtering
   const usedTopics = useMemo(() => {
@@ -50,26 +77,52 @@ const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onS
       });
     });
 
-    // Also check dialog information functions (if any actions are directly on dialogs, though actions are usually on functions)
-    // The parser puts actions on DialogFunction, which are linked from Dialog.
-
     return used;
   }, [semanticModel.functions]);
 
   const filteredQuests = useMemo(() => {
     return quests.filter(q => {
+      const analysis = questAnalysisMap.get(q.name);
+
+      // Text Filter
       const matchesSearch = q.name.toLowerCase().includes(filter.toLowerCase()) ||
                             String(q.value).toLowerCase().includes(filter.toLowerCase());
 
       if (!matchesSearch) return false;
 
-      if (viewMode === 'used') {
-        return usedTopics.has(q.name);
+      // View Mode Filter
+      if (viewMode === 'used' && !usedTopics.has(q.name)) {
+        return false;
+      }
+
+      // Status Filter
+      if (statusFilter !== 'all' && analysis?.status !== statusFilter) {
+          return false;
       }
 
       return true;
     });
-  }, [quests, filter, viewMode, usedTopics]);
+  }, [quests, filter, viewMode, statusFilter, usedTopics, questAnalysisMap]);
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case 'implemented': return <CheckIcon color="success" fontSize="small" />;
+      case 'wip': return <BuildIcon color="info" fontSize="small" />;
+      case 'broken': return <ReportIcon color="error" fontSize="small" />;
+      case 'not_started': return <HourglassEmptyIcon color="disabled" fontSize="small" />;
+      default: return <HourglassEmptyIcon color="disabled" fontSize="small" />;
+    }
+  };
+
+  const getStatusTooltip = (status: string) => {
+      switch (status) {
+        case 'implemented': return 'Implemented (Start & End)';
+        case 'wip': return 'In Progress (Start but no End)';
+        case 'broken': return 'Broken (Missing Variable)';
+        case 'not_started': return 'Not Started (No actions)';
+        default: return '';
+      }
+  };
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', borderRight: 1, borderColor: 'divider' }}>
@@ -95,54 +148,90 @@ const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onS
               </InputAdornment>
             ),
           }}
-          sx={{ mb: 2 }}
+          sx={{ mb: 1 }}
         />
-        <ToggleButtonGroup
-          value={viewMode}
-          exclusive
-          onChange={(_, mode) => mode && setViewMode(mode)}
-          fullWidth
-          size="small"
-        >
-          <ToggleButton value="all">All</ToggleButton>
-          <ToggleButton value="used">Used</ToggleButton>
-        </ToggleButtonGroup>
+
+        <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
+             <ToggleButtonGroup
+              value={viewMode}
+              exclusive
+              onChange={(_, mode) => mode && setViewMode(mode)}
+              size="small"
+              sx={{ flexGrow: 1 }}
+            >
+              <ToggleButton value="all" sx={{ flexGrow: 1 }}>All</ToggleButton>
+              <ToggleButton value="used" sx={{ flexGrow: 1 }}>Used</ToggleButton>
+            </ToggleButtonGroup>
+
+            <FormControl size="small" sx={{ minWidth: 100 }}>
+                <Select
+                    value={statusFilter}
+                    onChange={(e) => setStatusFilter(e.target.value as any)}
+                    displayEmpty
+                    variant="outlined"
+                    inputProps={{ 'aria-label': 'Status Filter' }}
+                    renderValue={(selected) => {
+                        if (selected === 'all') return <FilterListIcon fontSize="small" />;
+                        return getStatusIcon(selected);
+                    }}
+                >
+                    <MenuItem value="all">All Statuses</MenuItem>
+                    <MenuItem value="implemented"><Box sx={{display:'flex', gap:1}}><CheckIcon fontSize="small" color="success"/> Implemented</Box></MenuItem>
+                    <MenuItem value="wip"><Box sx={{display:'flex', gap:1}}><BuildIcon fontSize="small" color="info"/> In Progress</Box></MenuItem>
+                    <MenuItem value="not_started"><Box sx={{display:'flex', gap:1}}><HourglassEmptyIcon fontSize="small" color="disabled"/> Not Started</Box></MenuItem>
+                    <MenuItem value="broken"><Box sx={{display:'flex', gap:1}}><ReportIcon fontSize="small" color="error"/> Broken</Box></MenuItem>
+                </Select>
+            </FormControl>
+        </Box>
       </Box>
       <Divider />
       <List sx={{ flexGrow: 1, overflow: 'auto' }}>
-        {filteredQuests.map((quest) => (
-          <ListItem 
-            key={quest.name} 
-            disablePadding
-            secondaryAction={
-              <Tooltip title="Follow reference" arrow>
-                <IconButton 
-                  edge="end" 
-                  size="small" 
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    navigateToSymbol(quest.name, { preferSource: true });
-                  }}
-                >
-                  <OpenInNewIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-            }
-          >
-            <ListItemButton
-              selected={selectedQuest === quest.name}
-              onClick={() => onSelectQuest(quest.name)}
+        {filteredQuests.map((quest) => {
+          const analysis = questAnalysisMap.get(quest.name);
+          const status = analysis?.status || 'not_started';
+
+          return (
+            <ListItem
+              key={quest.name}
+              disablePadding
+              secondaryAction={
+                <Tooltip title="Follow reference" arrow>
+                  <IconButton
+                    edge="end"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigateToSymbol(quest.name, { preferSource: true });
+                    }}
+                  >
+                    <OpenInNewIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              }
             >
-              <ListItemText
-                primary={String(quest.value).replace(/^"|"$/g, '')} // Strip quotes for display
-                secondary={quest.name}
-              />
-            </ListItemButton>
-          </ListItem>
-        ))}
+              <ListItemButton
+                selected={selectedQuest === quest.name}
+                onClick={() => onSelectQuest(quest.name)}
+                sx={{ pr: 6 }}
+              >
+                <ListItemIcon sx={{ minWidth: 30 }}>
+                    <Tooltip title={getStatusTooltip(status)}>
+                        {getStatusIcon(status)}
+                    </Tooltip>
+                </ListItemIcon>
+                <ListItemText
+                  primary={String(quest.value).replace(/^"|"$/g, '')} // Strip quotes for display
+                  secondary={quest.name}
+                  primaryTypographyProps={{ noWrap: true }}
+                  secondaryTypographyProps={{ noWrap: true, fontSize: '0.75rem' }}
+                />
+              </ListItemButton>
+            </ListItem>
+          );
+        })}
         {filteredQuests.length === 0 && (
           <ListItem>
-            <ListItemText secondary="No quests found" />
+            <ListItemText secondary="No quests found" sx={{ textAlign: 'center', fontStyle: 'italic', color: 'text.secondary' }} />
           </ListItem>
         )}
       </List>


### PR DESCRIPTION
Improved the UX of diary/quest management by leveraging knowledge about topic and mission variables.
- Implemented `analyzeQuest` to infer quest status from the semantic model.
- Enhanced `QuestList` with status icons and filtering capabilities.
- Enhanced `QuestDetails` with:
    - Status visualization.
    - "Create Variable" button for missing `MIS_` variables.
    - Editable quest description (updates `TOPIC_` constant value).
- Added `updateGlobalConstant` to `ProjectStore` to handle file updates for constants.

---
*PR created automatically by Jules for task [67189205961682922](https://jules.google.com/task/67189205961682922) started by @daniel-daga*