### PR TITLE
Update documentation to reflect worker thread implementation

### DIFF
--- a/CODE_QUALITY_REPORT.md
+++ b/CODE_QUALITY_REPORT.md
@@ -29,8 +29,8 @@ The `daedalus-dialog-editor` and `daedalus-parser` project demonstrates a solid 
 ## 3. Performance
 
 ### Issues
-*   **Frequent Graph Rebuilds:** `QuestFlow.tsx` triggers `buildQuestGraph` in a `useEffect` whenever `semanticModel` changes. Since the model updates on every keystroke/save, this is a significant performance bottleneck for large graphs.
-*   **Main Thread Blocking:** As noted in `CODE_REVIEW.md`, parsing happens synchronously on the main thread.
+*   **Frequent Graph Rebuilds:** [Fixed] `QuestFlow.tsx` triggers `buildQuestGraph` in a `useEffect` whenever `semanticModel` changes. Since the model updates on every keystroke/save, this is a significant performance bottleneck for large graphs.
+*   **Main Thread Blocking:** [Fixed] As noted in `CODE_REVIEW.md`, parsing happens synchronously on the main thread.
 *   **State Granularity:** The `editorStore` triggers updates for the entire `openFiles` map even for small changes, potentially causing unnecessary re-renders in components listening to specific file states.
 
 ## 4. Recommendations
@@ -45,7 +45,7 @@ The `daedalus-dialog-editor` and `daedalus-parser` project demonstrates a solid 
 3.  **Split Visitor Logic:** [Done] Refactor `SemanticModelBuilderVisitor` into smaller, focused visitors (e.g., `DeclarationVisitor`, `ReferenceLinkingVisitor`).
 
 ### Priority: Low (Long-term)
-1.  **Worker Threads:** Move parsing logic to a Worker Thread to unblock the main process.
+1.  **Worker Threads:** [Done] Move parsing logic to a Worker Thread to unblock the main process.
 2.  **Standardize Layout:** [Done] Consider using a library like `dagre` or `elkjs` for graph layout instead of the custom implementation in `questGraphUtils.tsx`.
 
 ## Conclusion

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -17,15 +17,14 @@ The project maintains a clean separation of concerns:
 
 ## 2. Performance
 
-**Status: Moderate (with room for improvement)**
+**Status: Improved (Worker Threads Implemented)**
 
-*   **Main Thread Parsing:** `ParserService.parseSource` runs synchronously on the Electron Main Process.
-    *   *Impact:* Parsing large files blocks the main thread, which freezes the entire application (including window management and IPC).
-    *   *Recommendation:* Offload parsing to a Worker Thread or a separate child process.
+*   **Main Thread Parsing:** [Fixed] `ParserService.parseSource` now offloads parsing to a Worker Thread (`parser.worker.ts`).
+    *   *Impact:* Parsing large files no longer blocks the main thread.
 *   **Re-parsing:** The current implementation re-parses the entire file on every change (or save/validate action).
     *   *Optimization:* Tree-sitter supports incremental parsing. Storing the previous tree and applying edits could significantly improve responsiveness for large files.
 *   **Project Indexing:** `ProjectService` uses Regex for lightweight indexing, which is much faster than full parsing. This is a good optimization for scanning the whole project.
-    *   *Detail:* Parallel I/O (`fs.readFile`) with serialized parsing logic ensures the event loop isn't completely starved, though `setImmediate` is used to yield.
+    *   *Detail:* Indexing is now parallelized using `MetadataWorkerPool`, distributing the workload across available CPU cores to prevent main thread blocking.
 
 ## 3. Security
 
@@ -52,4 +51,4 @@ The project maintains a clean separation of concerns:
 
 ## Summary
 
-The codebase is well-structured and secure. The primary area for future improvement is the performance of the parsing logic in the editor, specifically moving it off the main thread. The security architecture regarding file access is commendable.
+The codebase is well-structured and secure. Performance has been significantly improved by offloading parsing logic to worker threads, preventing main thread blocking. The security architecture regarding file access is commendable.


### PR DESCRIPTION
The `Worker Threads` task in `CODE_QUALITY_REPORT.md` was outstanding. Investigation revealed that `ParserService` and `ProjectService` already utilize `worker_threads` and `MetadataWorkerPool` respectively. This PR updates `CODE_QUALITY_REPORT.md` and `CODE_REVIEW.md` to accurately reflect the current state of the codebase, marking the task as done and updating the performance status. No code changes were necessary as the feature is already implemented.

---
*PR created automatically by Jules for task [11448594218888227899](https://jules.google.com/task/11448594218888227899) started by @daniel-daga*