### PR TITLE
Refactor Quest UI logic into questAnalysis.ts

### DIFF
--- a/CODE_QUALITY_REPORT.md
+++ b/CODE_QUALITY_REPORT.md
@@ -14,7 +14,7 @@ The `daedalus-dialog-editor` and `daedalus-parser` project demonstrates a solid 
 ### Weaknesses
 *   **Coupling in Parser:** `SemanticModelBuilderVisitor` is responsible for parsing, linking, *and* analyzing logic. As the language support grows, this file will become unmaintainable.
 *   **Manual Serialization:** `semantic-model.ts` relies on repetitive `fromJSON` and `toJSON` methods. This boilerplate is error-prone and hard to maintain as the model evolves.
-*   **Tangled UI Logic:** `QuestGraph.tsx` and `QuestEditor.tsx` mix UI presentation with complex data transformation logic (`questGraphUtils.tsx`).
+*   **Tangled UI Logic:** [Fixed] `QuestGraph.tsx` and `QuestEditor.tsx` logic has been decoupled into `questAnalysis.ts`, separating UI from data transformation.
 
 ## 2. Code Quality & Style
 

--- a/daedalus-dialog-editor/src/renderer/components/QuestEditor/questAnalysis.ts
+++ b/daedalus-dialog-editor/src/renderer/components/QuestEditor/questAnalysis.ts
@@ -1,0 +1,170 @@
+import type { SemanticModel, DialogAction, DialogCondition } from '../../types/global';
+import { getActionType } from '../actionTypes';
+
+export interface QuestAnalysis {
+    status: 'implemented' | 'wip' | 'broken' | 'not_started';
+    misVariableExists: boolean;
+    misVariableName: string;
+    hasStart: boolean;
+    hasSuccess: boolean;
+    hasFailed: boolean;
+    description: string;
+    filePaths: { topic: string | null; variable: string | null };
+}
+
+export interface QuestReference {
+    type: 'create' | 'status' | 'entry';
+    dialogName?: string;
+    functionName: string;
+    npcName?: string;
+    details: string;
+}
+
+export const analyzeQuest = (semanticModel: SemanticModel, questName: string): QuestAnalysis => {
+    const misVarName = questName.replace('TOPIC_', 'MIS_');
+    const topicConstant = semanticModel.constants?.[questName];
+    const misVariable = semanticModel.variables?.[misVarName];
+
+    let hasStart = false;
+    let hasSuccess = false;
+    let hasFailed = false;
+
+    // Scan functions for actions
+    Object.values(semanticModel.functions || {}).forEach(func => {
+        func.actions?.forEach((action: DialogAction) => {
+            if ('topic' in action && action.topic === questName) {
+                if (action.type === 'CreateTopic') {
+                    hasStart = true;
+                } else if (action.type === 'LogSetTopicStatus') {
+                    const status = String(action.status);
+                    if (status.includes('SUCCESS') || status === '2') {
+                        hasSuccess = true;
+                    } else if (status.includes('FAILED') || status === '3') {
+                        hasFailed = true;
+                    }
+                }
+            }
+        });
+    });
+
+    let status: QuestAnalysis['status'] = 'not_started';
+    if (!misVariable) {
+        status = 'broken';
+    } else if (hasSuccess || hasFailed) {
+        status = 'implemented';
+    } else if (hasStart) {
+        status = 'wip';
+    }
+
+    return {
+        status,
+        misVariableExists: !!misVariable,
+        misVariableName: misVarName,
+        hasStart,
+        hasSuccess,
+        hasFailed,
+        description: topicConstant ? String(topicConstant.value).replace(/^"|"$/g, '') : '',
+        filePaths: {
+            topic: topicConstant?.filePath || null,
+            variable: misVariable?.filePath || null
+        }
+    };
+};
+
+export const getQuestReferences = (semanticModel: SemanticModel, questName: string): QuestReference[] => {
+    if (!questName) return [];
+    const lowerQuestName = questName.toLowerCase();
+    const misVarName = questName.replace('TOPIC_', 'MIS_');
+    const lowerMisVarName = misVarName.toLowerCase();
+
+    const refs: QuestReference[] = [];
+
+    // Map functions to dialogs for better context
+    const funcToDialog = new Map<string, { dialogName: string, npcName?: string }>();
+    Object.values(semanticModel.dialogs || {}).forEach(dialog => {
+        const info = dialog.properties.information;
+        if (typeof info === 'string') {
+            funcToDialog.set(info.toLowerCase(), { dialogName: dialog.name, npcName: dialog.properties.npc });
+        } else if (info && typeof info === 'object' && info.name) {
+             funcToDialog.set(info.name.toLowerCase(), { dialogName: dialog.name, npcName: dialog.properties.npc });
+        }
+    });
+
+    Object.values(semanticModel.functions || {}).forEach(func => {
+        func.actions?.forEach(action => {
+            if ('topic' in action && action.topic && action.topic.toLowerCase() === lowerQuestName) {
+                const context = funcToDialog.get(func.name.toLowerCase());
+                const type = getActionType(action);
+
+                if (type === 'createTopic') {
+                     refs.push({
+                        type: 'create',
+                        functionName: func.name,
+                        dialogName: context?.dialogName,
+                        npcName: context?.npcName,
+                        details: `Created${(action as any).topicType ? ` in ${(action as any).topicType}` : ''}`
+                     });
+                } else if (type === 'logSetTopicStatus') {
+                     refs.push({
+                        type: 'status',
+                        functionName: func.name,
+                        dialogName: context?.dialogName,
+                        npcName: context?.npcName,
+                        details: `Set status to ${(action as any).status}`
+                     });
+                } else if (type === 'logEntry') {
+                     refs.push({
+                        type: 'entry',
+                        functionName: func.name,
+                        dialogName: context?.dialogName,
+                        npcName: context?.npcName,
+                        details: `Entry: "${(action as any).text}"`
+                     });
+                }
+            }
+        });
+
+        // Check conditions for MIS_ var
+        func.conditions?.forEach(cond => {
+             // Basic check for variable condition structure as serialized
+             if ('variableName' in cond && cond.variableName && (cond as any).variableName.toLowerCase() === lowerMisVarName) {
+                 const context = funcToDialog.get(func.name.toLowerCase());
+                 refs.push({
+                    type: 'status',
+                    functionName: func.name,
+                    dialogName: context?.dialogName,
+                    npcName: context?.npcName,
+                    details: `Condition: ${(cond as any).negated ? '!' : ''}${misVarName}`
+                 });
+             }
+        });
+    });
+
+    return refs;
+};
+
+export const getUsedQuestTopics = (semanticModel: SemanticModel): Set<string> => {
+    const used = new Set<string>();
+
+    // Check all functions for Log_* calls
+    Object.values(semanticModel.functions || {}).forEach(func => {
+      func.actions?.forEach(action => {
+        if ('topic' in action && action.topic) {
+           used.add(action.topic);
+        }
+      });
+    });
+
+    return used;
+};
+
+export const findDialogNameForFunction = (semanticModel: SemanticModel, funcName: string): string | null => {
+    for (const [dName, d] of Object.entries(semanticModel.dialogs || {})) {
+        const info = d.properties.information;
+        if ((typeof info === 'string' && info.toLowerCase() === funcName.toLowerCase()) ||
+            (typeof info === 'object' && info.name.toLowerCase() === funcName.toLowerCase())) {
+            return dName;
+        }
+    }
+    return null;
+};

--- a/daedalus-dialog-editor/src/renderer/components/QuestFlow.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestFlow.tsx
@@ -16,6 +16,7 @@ import { Box, Typography } from '@mui/material';
 import type { SemanticModel } from '../types/global';
 import { useNavigation } from '../hooks/useNavigation';
 import { buildQuestGraph } from './QuestEditor/questGraphUtils';
+import { findDialogNameForFunction } from './QuestEditor/questAnalysis';
 
 import DialogNode from './QuestEditor/Nodes/DialogNode';
 import QuestStateNode from './QuestEditor/Nodes/QuestStateNode';
@@ -40,28 +41,16 @@ const QuestFlow: React.FC<QuestFlowProps> = ({ semanticModel, questName }) => {
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
 
-  // Helper to find dialog name for a function
-  const findDialogForFunction = useCallback((funcName: string) => {
-    for (const [dName, d] of Object.entries(semanticModel.dialogs || {})) {
-        const info = d.properties.information;
-        if ((typeof info === 'string' && info.toLowerCase() === funcName.toLowerCase()) ||
-            (typeof info === 'object' && info.name.toLowerCase() === funcName.toLowerCase())) {
-            return dName;
-        }
-    }
-    return null;
-  }, [semanticModel.dialogs]);
-
   const onNodeClick = useCallback((event: React.MouseEvent, node: Node) => {
     if (node.type === 'group') return;
     
-    const dialogName = findDialogForFunction(node.id);
+    const dialogName = findDialogNameForFunction(semanticModel, node.id);
     if (dialogName) {
       navigateToDialog(dialogName);
     } else {
       navigateToSymbol(node.id);
     }
-  }, [findDialogForFunction, navigateToDialog, navigateToSymbol]);
+  }, [semanticModel, navigateToDialog, navigateToSymbol]);
 
   const onConnect = useCallback((params: Connection) => {
     // In the future: This should also update the semantic model (e.g., adding Npc_KnowsInfo)

--- a/daedalus-dialog-editor/src/renderer/components/QuestList.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestList.tsx
@@ -32,7 +32,7 @@ import {
 import type { SemanticModel } from '../types/global';
 import CreateQuestDialog from './CreateQuestDialog';
 import { useNavigation } from '../hooks/useNavigation';
-import { analyzeQuest } from './QuestEditor/questGraphUtils';
+import { analyzeQuest, getUsedQuestTopics } from './QuestEditor/questAnalysis';
 
 interface QuestListProps {
   semanticModel: SemanticModel;
@@ -66,19 +66,8 @@ const QuestList: React.FC<QuestListProps> = ({ semanticModel, selectedQuest, onS
 
   // Memoize the set of used topics to enable "Used" filtering
   const usedTopics = useMemo(() => {
-    const used = new Set<string>();
-
-    // Check all functions for Log_* calls
-    Object.values(semanticModel.functions || {}).forEach(func => {
-      func.actions?.forEach(action => {
-        if ('topic' in action && action.topic) {
-           used.add(action.topic);
-        }
-      });
-    });
-
-    return used;
-  }, [semanticModel.functions]);
+    return getUsedQuestTopics(semanticModel);
+  }, [semanticModel]);
 
   const filteredQuests = useMemo(() => {
     return quests.filter(q => {

--- a/daedalus-dialog-editor/tests/questAnalysis.test.ts
+++ b/daedalus-dialog-editor/tests/questAnalysis.test.ts
@@ -1,0 +1,173 @@
+import { analyzeQuest, getQuestReferences, getUsedQuestTopics, findDialogNameForFunction } from '../src/renderer/components/QuestEditor/questAnalysis';
+import type { SemanticModel } from '../src/renderer/types/global';
+
+// Mock Semantic Model Helper
+const createMockModel = (functions: any[], dialogs: any[], constants: any[] = [], variables: any[] = []): SemanticModel => {
+    const funcMap: Record<string, any> = {};
+    functions.forEach(f => funcMap[f.name] = f);
+
+    const dialogMap: Record<string, any> = {};
+    dialogs.forEach(d => dialogMap[d.name] = d);
+
+    const constMap: Record<string, any> = {};
+    constants.forEach(c => constMap[c.name] = c);
+
+    const varMap: Record<string, any> = {};
+    variables.forEach(v => varMap[v.name] = v);
+
+    return {
+        functions: funcMap,
+        dialogs: dialogMap,
+        constants: constMap,
+        variables: varMap,
+        instances: {},
+        classes: {},
+        structs: {},
+    } as SemanticModel;
+};
+
+describe('questAnalysis', () => {
+    describe('analyzeQuest', () => {
+        it('should correctly analyze an implemented quest', () => {
+            const questName = 'TOPIC_TEST';
+            const misVarName = 'MIS_TEST';
+
+            const constants = [{ name: questName, value: '"Test Quest"', filePath: 'Topics.d' }];
+            const variables = [{ name: misVarName, type: 'int', filePath: 'Topics.d' }];
+
+            const functions = [
+                {
+                    name: 'DIA_Start',
+                    actions: [{ type: 'CreateTopic', topic: questName }]
+                },
+                {
+                    name: 'DIA_End',
+                    actions: [{ type: 'LogSetTopicStatus', topic: questName, status: 'LOG_SUCCESS' }]
+                }
+            ];
+
+            const model = createMockModel(functions, [], constants, variables);
+            const result = analyzeQuest(model, questName);
+
+            expect(result.status).toBe('implemented');
+            expect(result.misVariableExists).toBe(true);
+            expect(result.hasStart).toBe(true);
+            expect(result.hasSuccess).toBe(true);
+            expect(result.description).toBe('Test Quest');
+        });
+
+        it('should detect WIP quest (no end)', () => {
+            const questName = 'TOPIC_WIP';
+            const misVarName = 'MIS_WIP';
+
+            const constants = [{ name: questName, value: '"WIP Quest"' }];
+            const variables = [{ name: misVarName, type: 'int' }];
+
+            const functions = [
+                {
+                    name: 'DIA_Start',
+                    actions: [{ type: 'CreateTopic', topic: questName }]
+                }
+            ];
+
+            const model = createMockModel(functions, [], constants, variables);
+            const result = analyzeQuest(model, questName);
+
+            expect(result.status).toBe('wip');
+            expect(result.hasStart).toBe(true);
+            expect(result.hasSuccess).toBe(false);
+        });
+
+        it('should detect broken quest (missing variable)', () => {
+            const questName = 'TOPIC_BROKEN';
+            // No variable definition
+
+            const model = createMockModel([], [], [{ name: questName, value: '"Broken"' }], []);
+            const result = analyzeQuest(model, questName);
+
+            expect(result.status).toBe('broken');
+            expect(result.misVariableExists).toBe(false);
+        });
+    });
+
+    describe('getQuestReferences', () => {
+        it('should find references to quest usage', () => {
+            const questName = 'TOPIC_REF';
+            const misVarName = 'MIS_REF';
+
+            const functions = [
+                {
+                    name: 'DIA_Start_Info',
+                    actions: [{ type: 'CreateTopic', topic: questName, topicType: 'LOG_MISSION' }]
+                },
+                {
+                    name: 'DIA_Check_Info',
+                    conditions: [
+                        { type: 'VariableCondition', variableName: misVarName, negated: false }
+                    ]
+                }
+            ];
+
+            const dialogs = [
+                { name: 'DIA_Start', properties: { information: 'DIA_Start_Info', npc: 'NPC_A' } },
+                { name: 'DIA_Check', properties: { information: 'DIA_Check_Info', npc: 'NPC_B' } }
+            ];
+
+            const model = createMockModel(functions, dialogs);
+            const refs = getQuestReferences(model, questName);
+
+            expect(refs).toHaveLength(2);
+
+            const startRef = refs.find(r => r.functionName === 'DIA_Start_Info');
+            expect(startRef).toBeDefined();
+            expect(startRef?.type).toBe('create');
+            expect(startRef?.npcName).toBe('NPC_A');
+
+            const checkRef = refs.find(r => r.functionName === 'DIA_Check_Info');
+            expect(checkRef).toBeDefined();
+            expect(checkRef?.type).toBe('status');
+            expect(checkRef?.npcName).toBe('NPC_B');
+        });
+    });
+
+    describe('getUsedQuestTopics', () => {
+        it('should return unique set of topics used in actions', () => {
+            const functions = [
+                {
+                    name: 'F1',
+                    actions: [{ type: 'LogEntry', topic: 'TOPIC_A', text: '...' }]
+                },
+                {
+                    name: 'F2',
+                    actions: [
+                        { type: 'LogSetTopicStatus', topic: 'TOPIC_A', status: '...' },
+                        { type: 'CreateTopic', topic: 'TOPIC_B' }
+                    ]
+                }
+            ];
+
+            const model = createMockModel(functions, []);
+            const used = getUsedQuestTopics(model);
+
+            expect(used.size).toBe(2);
+            expect(used.has('TOPIC_A')).toBe(true);
+            expect(used.has('TOPIC_B')).toBe(true);
+        });
+    });
+
+    describe('findDialogNameForFunction', () => {
+        it('should resolve function name to dialog name', () => {
+            const dialogs = [
+                { name: 'DIA_A', properties: { information: 'DIA_A_Info' } },
+                { name: 'DIA_B', properties: { information: { name: 'DIA_B_Info' } } }
+            ];
+
+            const model = createMockModel([], dialogs);
+
+            expect(findDialogNameForFunction(model, 'DIA_A_Info')).toBe('DIA_A');
+            expect(findDialogNameForFunction(model, 'dia_a_info')).toBe('DIA_A'); // Case insensitive
+            expect(findDialogNameForFunction(model, 'DIA_B_Info')).toBe('DIA_B');
+            expect(findDialogNameForFunction(model, 'Unknown')).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
This PR addresses the "Tangled UI Logic" issue from the Code Quality Report. It decouples the quest analysis and data transformation logic from the UI components (`QuestDetails`, `QuestList`, `QuestFlow`) and the graph visualization utility (`questGraphUtils`).

Key changes:
1.  Created `daedalus-dialog-editor/src/renderer/components/QuestEditor/questAnalysis.ts` to house business logic for quests.
2.  Refactored `QuestDetails.tsx` to use `getQuestReferences` from the new module.
3.  Refactored `QuestList.tsx` to use `getUsedQuestTopics` and `analyzeQuest` from the new module.
4.  Refactored `QuestFlow.tsx` to use `findDialogNameForFunction` from the new module.
5.  Cleaned up `questGraphUtils.tsx` by removing the unused `analyzeQuest` function.
6.  Added comprehensive unit tests for the extracted logic.

This improves maintainability and testability of the quest editor components.

---
*PR created automatically by Jules for task [16908380935616098675](https://jules.google.com/task/16908380935616098675) started by @daniel-daga*