### PR TITLE
Simplify editor save controls when autosave is enabled

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/DialogDetailsEditor.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/DialogDetailsEditor.tsx
@@ -4,13 +4,11 @@ import {
   Typography,
   Stack,
   Button,
-  Chip,
   Snackbar,
   Alert,
   CircularProgress
 } from '@mui/material';
 import {
-  Save as SaveIcon,
   Code as CodeIcon
 } from '@mui/icons-material';
 import { useEditorStore } from '../store/editorStore';
@@ -55,7 +53,6 @@ const DialogDetailsEditor: React.FC<DialogDetailsEditorProps> = ({
     addActionToEnd,
     handleDialogPropertyChange,
     handleConditionFunctionUpdate,
-    handleSave,
     handleSaveAnyway,
     handleCancelValidation,
     handleReset
@@ -105,7 +102,6 @@ const DialogDetailsEditor: React.FC<DialogDetailsEditorProps> = ({
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <Typography variant="h5">{dialogName}</Typography>
-          {isDirty && <Chip label="Unsaved Changes" size="small" color="error" />}
         </Box>
         <Stack direction="row" spacing={1}>
           <Button
@@ -122,15 +118,6 @@ const DialogDetailsEditor: React.FC<DialogDetailsEditorProps> = ({
             startIcon={uiState.isResetting ? <CircularProgress size={16} /> : undefined}
           >
             {uiState.isResetting ? 'Resetting...' : 'Reset'}
-          </Button>
-          <Button
-            variant="contained"
-            color="success"
-            startIcon={uiState.isSaving ? <CircularProgress size={16} sx={{ color: 'white' }} /> : <SaveIcon />}
-            disabled={!isDirty || uiState.isSaving || uiState.isResetting}
-            onClick={() => handleSave()}
-          >
-            {uiState.isSaving ? 'Saving...' : 'Save'}
           </Button>
         </Stack>
       </Box>

--- a/daedalus-dialog-editor/tests/e2e/file-opening.spec.ts
+++ b/daedalus-dialog-editor/tests/e2e/file-opening.spec.ts
@@ -94,8 +94,8 @@ test.describe('File Opening and Dialog Selection', () => {
     await expect(page.getByRole('button', { name: /Add Line/i })).toBeVisible();
     await expect(page.getByRole('button', { name: /Add Choice/i })).toBeVisible();
 
-    // Verify Save button is present
-    await expect(page.getByRole('button', { name: /Save/i })).toBeVisible();
+    // Auto-save is enabled, so there is no explicit Save button in the editor toolbar
+    await expect(page.getByRole('button', { name: /Save/i })).toHaveCount(0);
   });
 
   test('should display dialog actions', async ({ page }) => {


### PR DESCRIPTION
### Motivation
- Autosave status is already shown in the app header, and having a per-editor "Unsaved Changes" chip plus a manual `Save` button created redundant and noisy UI.
- Consolidate save feedback into a single place to reduce visual clutter and avoid toggling a manual save button while autosave is active.

### Description
- Removed the per-editor `Chip` that displayed "Unsaved Changes" from `DialogDetailsEditor` so save state is no longer duplicated in the editor header.
- Removed the manual `Save` button and the `SaveIcon` import from `daedalus-dialog-editor/src/renderer/components/DialogDetailsEditor.tsx`, and removed `handleSave` usage from that component's command destructuring.
- Updated the E2E spec `daedalus-dialog-editor/tests/e2e/file-opening.spec.ts` to assert that no explicit `Save` button is present when autosave is enabled.

### Testing
- Attempted to run the dev server with `npm run dev:browser`, but it failed in this environment because `vite` was not available (error: `vite: not found`).
- Attempted to run the project tests with `npm run test --workspace daedalus-dialog-editor -- DialogDetailsEditor`, but it failed because `jest` was not available in the environment (error: `jest: not found`).
- No automated tests passed locally due to missing dev/test toolchain binaries in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d902a22c88332b72c44784506d1ac)