### PR TITLE
Create dedicated NPC dialog files when adding new NPCs

### DIFF
--- a/daedalus-dialog-editor/tests/e2e/dialog-creation.spec.ts
+++ b/daedalus-dialog-editor/tests/e2e/dialog-creation.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+const EXISTING_DIALOG_FILE = `INSTANCE DIA_Existing_Greeting(C_INFO)
+{
+\tnpc = SLD_11111_Existing;
+\tnr = 1;
+\tcondition = DIA_Existing_Greeting_Condition;
+\tinformation = DIA_Existing_Greeting_Info;
+\timportant = FALSE;
+};
+
+FUNC INT DIA_Existing_Greeting_Condition()
+{
+\treturn TRUE;
+};
+
+FUNC VOID DIA_Existing_Greeting_Info()
+{
+\tAI_Output(self, other, "DIA_Existing_Greeting_15_00");
+};
+`;
+
+test.describe('Dialog creation flow', () => {
+  test('creates a dedicated file when adding a new NPC in project mode', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText('Welcome to Dandelion')).toBeVisible();
+
+    await page.evaluate((content) => {
+      localStorage.setItem('mockapi_file_project/dialogs/existing.d', content);
+    }, EXISTING_DIALOG_FILE);
+
+    page.on('dialog', async (dialog) => {
+      if (dialog.message().includes('project folder path')) {
+        await dialog.accept('project/dialogs');
+      } else {
+        await dialog.dismiss();
+      }
+    });
+
+    await page.getByRole('button', { name: /Open Project/i }).first().click();
+    await expect(page.getByText('SLD_11111_Existing')).toBeVisible({ timeout: 15000 });
+
+    await page.getByRole('button', { name: 'Add NPC' }).click();
+    await page.getByLabel('NPC Name').fill('SLD_12345_TestNpc');
+    await page.getByRole('button', { name: 'Create' }).click();
+
+    await expect(page.getByText('SLD_12345_TestNpc')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'DIA_SLD_12345_TestNpc_Start', exact: true })).toBeVisible();
+
+    const storageState = await page.evaluate(() => {
+      return {
+        npcFile: localStorage.getItem('mockapi_file_project/dialogs/DIA_SLD_12345_TestNpc.d'),
+        existingFile: localStorage.getItem('mockapi_file_project/dialogs/existing.d')
+      };
+    });
+
+    expect(storageState.npcFile).not.toBeNull();
+    expect(storageState.existingFile).not.toContain('DIA_SLD_12345_TestNpc_Start');
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent new NPC dialogs from being appended to unrelated files by making each NPC get its own dialog file (`DIA_<NPC>.d`) in project mode.
- Keep existing behavior for existing NPC metadata and single-file mode while ensuring new files are reliably created and opened before parsing.

### Description
- Added path helpers `getDirectoryName` and `joinPath` to build cross-platform directory-safe paths.
- Made `resolveTargetFilePath` async and, in project mode, resolve to a per-NPC file `DIA_<NPC>.d` inside a sensible directory derived from `activeFile`, `filePath`, `allDialogFiles[0]`, or `projectPath`.
- Initialize the per-NPC file by calling `window.editorAPI.writeFile(preferredFilePath, '')` when the file is not already present in `allDialogFiles` and return that path for subsequent operations.
- Updated `createDialogForNpc` to `await` the new async `resolveTargetFilePath` and included `allDialogFiles`/`projectPath` in hook dependencies so model uniqueness checks and file opening continue to work.

### Testing
- Ran `npm run test --workspace daedalus-dialog-editor -- ThreeColumnLayout.test.tsx NPCList.test.tsx` and it failed in this environment with `jest: not found` so unit tests were not executed here.
- Attempted `npm ci` to install dependencies for running tests but the install did not complete within the run window, so automated tests could not be run to completion in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dc4c4b2a48332af4203d0e0cbd067)