### PR TITLE
Refactor dialog editor commands to use store-level updater APIs

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/DialogDetailsEditor.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/DialogDetailsEditor.tsx
@@ -28,10 +28,9 @@ const DialogDetailsEditor: React.FC<DialogDetailsEditorProps> = ({
   filePath,
   functionName,
   onNavigateToFunction,
-  semanticModel: passedSemanticModel,
-  isProjectMode = false
+  semanticModel: passedSemanticModel
 }) => {
-  const { openFiles, saveFile, updateDialog, updateFunction } = useEditorStore();
+  const { openFiles, saveFile, updateFunction } = useEditorStore();
   const fileState = filePath ? openFiles.get(filePath) : null;
   const semanticModel = fileState?.semanticModel || passedSemanticModel;
 
@@ -62,9 +61,7 @@ const DialogDetailsEditor: React.FC<DialogDetailsEditorProps> = ({
     currentFunctionName,
     currentFunction,
     semanticModel,
-    isProjectMode,
     saveFile,
-    updateDialog,
     updateFunction,
     focusAction,
     setIsSaving: uiState.setIsSaving,


### PR DESCRIPTION
### Motivation
- Reduce coupling between command orchestration and direct store state access so the command hook acts as a pure wiring layer and the store owns state retrieval/mutation semantics.
- Address a maintainability concern from the Editor Component Code Review where the hook mixed orchestration and state-access logic.

### Description
- Added `updateDialogWithUpdater` and `updateFunctionWithUpdater` actions to `useEditorStore` (`daedalus-dialog-editor/src/renderer/store/editorStore.ts`) that accept updater callbacks and apply mutations atomically while preserving dirty flags and project-store sync behavior.
- Refactored `useDialogEditorCommands` (`daedalus-dialog-editor/src/renderer/components/hooks/useDialogEditorCommands.ts`) to call the new store updater APIs instead of reading `getFileState` and mutating model fragments inside the hook, and removed the old `getFileState` usage.
- Simplified `DialogDetailsEditor` (`daedalus-dialog-editor/src/renderer/components/DialogDetailsEditor.tsx`) wiring by removing now-unused command parameters (`updateDialog` and `isProjectMode`) passed into the hook.
- Kept existing behaviors (dirty marking, working-code invalidation, project-store synchronization) unchanged in the new updater implementations.

### Testing
- Attempted to run `npm -C daedalus-dialog-editor run build`, which failed in this environment due to missing Electron/Node type packages and other dev dependencies causing TypeScript resolution errors.
- Attempted to run `npm -C daedalus-dialog-editor run build:renderer`, which failed because `vite` is not installed in the current environment (`sh: 1: vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1e12280083328451451bc82bcc72)