### PR TITLE
Add workflow_dispatch triggers to test workflows

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -1,6 +1,7 @@
 name: All Tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/roundtrip-corpus.yml
+++ b/.github/workflows/roundtrip-corpus.yml
@@ -1,6 +1,7 @@
 name: Roundtrip Corpus
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:


### PR DESCRIPTION
### Motivation
- Allow the test workflows to be started on-demand in addition to running on pushes to `main` and pull requests so checks can be run manually for debugging or ad-hoc validation.

### Description
- Added `workflow_dispatch` to the `on` section of the `Test` (`.github/workflows/test.yml`), `All Tests` (`.github/workflows/all-tests.yml`), and `Roundtrip Corpus` (`.github/workflows/roundtrip-corpus.yml`) workflows while keeping existing `push` and `pull_request` triggers, and left `Build Windows` unchanged.

### Testing
- Verified there were no issues with the repository after the edits by running `git diff --check` and `git status --short`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e2c879c9883329c4e8cdef49d2b1e)