### PR TITLE
Refactor dialog editor commands to use store-level mutation APIs

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/hooks/useDialogEditorCommands.ts
+++ b/daedalus-dialog-editor/src/renderer/components/hooks/useDialogEditorCommands.ts
@@ -5,7 +5,6 @@ import { createAction } from '../actionFactory';
 import type { ActionTypeId } from '../actionTypes';
 import type { DialogUpdater, FunctionUpdater } from '../dialogTypes';
 import type {
-  Dialog,
   DialogFunction,
   SemanticModel,
   ValidationResult
@@ -49,9 +48,10 @@ export function useDialogEditorCommands({
 }: UseDialogEditorCommandsParams) {
   const openFile = useEditorStore((state) => state.openFile);
   const renameFunction = useEditorStore((state) => state.renameFunction);
-  const updateDialogWithUpdater = useEditorStore((state) => state.updateDialogWithUpdater);
+  const updateDialogWithNormalizedProperties = useEditorStore((state) => state.updateDialogWithNormalizedProperties);
   const updateFunctionWithUpdater = useEditorStore((state) => state.updateFunctionWithUpdater);
   const updateDialogConditionFunction = useEditorStore((state) => state.updateDialogConditionFunction);
+  const replaceDialogConditionFunction = useEditorStore((state) => state.replaceDialogConditionFunction);
 
   const setFunction = useCallback((updatedFunctionOrUpdater: FunctionUpdater) => {
     if (!currentFunctionName || !filePath) {
@@ -115,24 +115,8 @@ export function useDialogEditorCommands({
       return;
     }
 
-    updateDialogWithUpdater(filePath, dialogName, (existingDialog) => {
-      const updatedDialog = updater(existingDialog);
-      const normalizedDialog: Dialog = {
-        ...updatedDialog,
-        properties: {
-          ...updatedDialog.properties,
-          information: typeof updatedDialog.properties?.information === 'object'
-            ? updatedDialog.properties.information.name
-            : updatedDialog.properties?.information,
-          condition: typeof updatedDialog.properties?.condition === 'object'
-            ? updatedDialog.properties.condition.name
-            : updatedDialog.properties?.condition
-        }
-      };
-
-      return normalizedDialog;
-    });
-  }, [dialogName, filePath, updateDialogWithUpdater]);
+    updateDialogWithNormalizedProperties(filePath, dialogName, updater);
+  }, [dialogName, filePath, updateDialogWithNormalizedProperties]);
 
   const handleConditionFunctionUpdate = useCallback((funcOrUpdater: FunctionUpdater) => {
     if (!filePath) {
@@ -144,8 +128,8 @@ export function useDialogEditorCommands({
       return;
     }
 
-    updateFunction(filePath, funcOrUpdater.name, funcOrUpdater);
-  }, [dialogName, filePath, updateDialogConditionFunction, updateFunction]);
+    replaceDialogConditionFunction(filePath, dialogName, funcOrUpdater);
+  }, [dialogName, filePath, replaceDialogConditionFunction, updateDialogConditionFunction]);
 
   const handleSave = useCallback(async (forceOnErrors = false) => {
     if (!filePath) {


### PR DESCRIPTION
### Motivation
- Decouple command wiring from store mutation policy so the dialog editor hook does not embed model-normalization or function-replacement logic.
- Centralize normalization of `properties.information` / `properties.condition` and dialog-aware condition-function replacement inside the editor store for consistency and maintainability.

### Description
- Added a new store API `updateDialogWithNormalizedProperties(filePath, dialogName, updater)` that applies an updater and normalizes `properties.information` and `properties.condition` to canonical string values inside the store layer (file: `src/renderer/store/editorStore.ts`).
- Added a new store API `replaceDialogConditionFunction(filePath, dialogName, updatedFunction)` that routes direct condition-function replacement through the dialog-aware update path (file: `src/renderer/store/editorStore.ts`).
- Updated `useDialogEditorCommands` to consume `updateDialogWithNormalizedProperties` and `replaceDialogConditionFunction` instead of performing ad-hoc normalization or calling `updateFunction` directly, keeping the hook focused on orchestration (file: `src/renderer/components/hooks/useDialogEditorCommands.ts`).
- Kept updater-based mutation flows intact and preserved updater compatibility for existing callers.

### Testing
- Ran package install with `npm ci` successfully.
- Ran unit tests `npm test -- DialogDetailsEditor.setFunction.test.tsx --runInBand` and `npm test -- DialogDetailsEditor.errorHandling.test.tsx --runInBand`, and both test suites passed.
- Built renderer with `npm run build:renderer` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4067ce408332b0838fbf6fc2caef)