### PR TITLE
Refactor parser condition literal conversion into shared utility

### DIFF
--- a/daedalus-parser/src/semantic/parsers/condition-parsers.ts
+++ b/daedalus-parser/src/semantic/parsers/condition-parsers.ts
@@ -12,7 +12,8 @@ import {
   Condition,
   VariableCondition
 } from '../semantic-model';
-import { parseArguments, normalizeArgumentText } from './argument-parsing';
+import { parseArguments } from './argument-parsing';
+import { parseLiteralOrIdentifier } from './literal-parsing';
 import { getBinaryOperator, isComparisonOperator } from './ast-constants';
 
 export class ConditionParsers {
@@ -291,13 +292,10 @@ export class ConditionParsers {
   }
 
   private static parseBinaryValue(node: TreeSitterNode): string | number | boolean {
-    if (node.type === 'number') {
-      return Number(node.text);
-    }
-    if (node.type === 'string') {
-      return normalizeArgumentText(node);
-    }
-    return node.text.trim();
+    return parseLiteralOrIdentifier(node, {
+      normalizeStringLiterals: true,
+      trimNonLiterals: true
+    });
   }
 
   private static invertComparisonOperator(operator: string): string {

--- a/daedalus-parser/src/semantic/parsers/literal-parsing.ts
+++ b/daedalus-parser/src/semantic/parsers/literal-parsing.ts
@@ -1,8 +1,19 @@
 import { TreeSitterNode } from '../semantic-model';
+import { normalizeArgumentText } from './argument-parsing';
 
 export type PrimitiveValue = string | number | boolean;
 
-export function parseLiteralOrIdentifier(node: TreeSitterNode): PrimitiveValue {
+type ParseLiteralOptions = {
+  normalizeStringLiterals?: boolean;
+  trimNonLiterals?: boolean;
+};
+
+export function parseLiteralOrIdentifier(
+  node: TreeSitterNode,
+  options: ParseLiteralOptions = {}
+): PrimitiveValue {
+  const { normalizeStringLiterals = false, trimNonLiterals = false } = options;
+
   if (node.type === 'number') {
     return Number(node.text);
   }
@@ -11,6 +22,9 @@ export function parseLiteralOrIdentifier(node: TreeSitterNode): PrimitiveValue {
     return node.text.toLowerCase() === 'true';
   }
 
-  return node.text;
-}
+  if (node.type === 'string') {
+    return normalizeStringLiterals ? normalizeArgumentText(node) : node.text;
+  }
 
+  return trimNonLiterals ? node.text.trim() : node.text;
+}


### PR DESCRIPTION
### Motivation
- A parser code-review noted duplicated primitive AST-to-value conversion logic across visitors/parsers, which increases maintenance risk and leads to subtle behavior drift. 
- The intent is to centralize literal/identifier parsing so condition parsing and other semantic passes share the same conversion rules.

### Description
- Extended `parseLiteralOrIdentifier` in `daedalus-parser/src/semantic/parsers/literal-parsing.ts` to accept options for `normalizeStringLiterals` and `trimNonLiterals` and to handle string nodes explicitly. 
- Replaced the ad-hoc binary-value conversion in `ConditionParsers.parseBinaryValue` with a call to the shared `parseLiteralOrIdentifier` helper in `daedalus-parser/src/semantic/parsers/condition-parsers.ts`. 
- Updated imports and removed the duplicated conversion branching from the condition parser to rely on the unified helper across semantic parsing code paths.

### Testing
- Ran the parser test command `cd daedalus-parser && npm test -- condition-parsing.test.js` which executes the parser semantic tests. 
- All executed tests passed successfully (the parser test run completed with all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ede2b2d4083329c5fceb7c68df908)