### PR TITLE
Stabilize editor scrollbar during dialog skeleton loading

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/DialogLoadingSkeleton.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/DialogLoadingSkeleton.tsx
@@ -7,7 +7,7 @@ import { Box, Paper, Skeleton, Stack } from '@mui/material';
  */
 const DialogLoadingSkeleton: React.FC = () => {
   return (
-    <Box sx={{ minHeight: '100%' }}>
+    <Box sx={{ minHeight: '100%', display: 'flex', flexDirection: 'column', gap: 2 }}>
       {/* Header skeleton */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Skeleton variant="text" width={200} height={40} />
@@ -19,7 +19,7 @@ const DialogLoadingSkeleton: React.FC = () => {
       </Box>
 
       {/* Properties skeleton */}
-      <Paper sx={{ p: 2, mb: 2, minHeight: 250 }}>
+      <Paper sx={{ p: 2, minHeight: 250 }}>
         <Skeleton variant="text" width={120} height={32} sx={{ mb: 2 }} />
         <Stack spacing={2}>
           <Skeleton variant="rectangular" height={40} sx={{ borderRadius: 1 }} />
@@ -30,7 +30,7 @@ const DialogLoadingSkeleton: React.FC = () => {
       </Paper>
 
       {/* Actions skeleton */}
-      <Paper sx={{ p: 2, minHeight: 460 }}>
+      <Paper sx={{ p: 2, minHeight: 460, flex: 1 }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
           <Box>
             <Skeleton variant="text" width={150} height={32} />

--- a/daedalus-dialog-editor/src/renderer/components/EditorPane.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/EditorPane.tsx
@@ -29,7 +29,9 @@ const TABS_HEIGHT = 40;
 
 const editorPaneContainerStyles = {
   flex: '1 1 auto',
-  overflow: 'auto',
+  overflowY: 'auto',
+  overflowX: 'hidden',
+  scrollbarGutter: 'stable',
   p: 0,
   minWidth: 0,
   display: 'flex',
@@ -134,18 +136,7 @@ const EditorPane = forwardRef<HTMLDivElement, EditorPaneProps>(({
 
   // Normal editing view
   return (
-    <Box
-      ref={ref}
-      sx={{
-        flex: '1 1 auto',
-        overflow: 'auto',
-        p: 0,
-        minWidth: 0,
-        display: 'flex',
-        flexDirection: 'column',
-        position: 'relative'
-      }}
-    >
+    <Box ref={ref} sx={editorPaneContainerStyles}>
       {tabsHeader}
 
       <Box sx={{ width: '100%', p: 2, minHeight: 0, flex: 1 }}>


### PR DESCRIPTION
### Motivation
- Prevent scrollbar pop-in/pop-out and layout jitter when switching between two different dialogs and the loading skeleton by making the skeleton and editor container have a consistent vertical footprint.
- Reserve scrollbar gutter and fix overflow behavior to avoid horizontal overflow and vertical scrollbar instability during transitions.

### Description
- Use a single editor container style in `EditorPane.tsx` and change `overflow` to `overflowY: 'auto'`, `overflowX: 'hidden'` and add `scrollbarGutter: 'stable'` so the pane keeps a stable vertical gutter across states.
- Replace the inline editor container in the normal view with the shared `editorPaneContainerStyles` to ensure identical layout for placeholder/loading/editor states.
- Update `DialogLoadingSkeleton.tsx` to a column flex layout with `gap: 2`, remove the extra bottom margin on the properties `Paper`, and make the actions `Paper` `flex: 1` so the skeleton’s height better matches real dialog content and reduces height variance.

### Testing
- Ran `npm run build --workspace daedalus-dialog-editor` which completed successfully.
- Started the renderer dev server (`npm run dev:browser`) and captured a Playwright screenshot of the editor pane as an automated smoke check which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ee3002db883328953f70cd610efb7)