### PR TITLE
docs: map autocomplete field conditions across editor forms

### DIFF
--- a/docs/AUTOCOMPLETE_FIELDS_INVESTIGATION.md
+++ b/docs/AUTOCOMPLETE_FIELDS_INVESTIGATION.md
@@ -1,0 +1,81 @@
+# Autocomplete field conditions investigation
+
+This document maps where `VariableAutocomplete` is used and what conditions determine which suggestions appear.
+
+## Core suggestion logic (`VariableAutocomplete`)
+
+Suggestions are built from:
+
+1. Constants from the local semantic model first, then merged project model.
+2. Variables from the local semantic model first, then merged project model.
+3. Instances only when `showInstances` is enabled.
+4. Dialogs from project `dialogIndex` only when `showDialogs` is enabled.
+
+Filtering behavior:
+
+- `typeFilter` must match the option type (case-insensitive).
+- `namePrefix` must match beginning of the option name (case-insensitive).
+- Duplicates are removed by lowercase name.
+- Dialog suggestions are tagged as type `C_INFO`.
+
+UX behavior:
+
+- If options > 2000 and input length < 2, normal suggestions are withheld.
+- In that large-list case, only an `Add "..."` creation suggestion is shown (if creation is enabled).
+- A `Follow reference` navigation icon appears only when the current value exactly matches a known option.
+
+## Condition editor (`ConditionCard`) autocomplete mapping
+
+Condition types using autocomplete:
+
+- `NpcKnowsInfoCondition`
+  - `NPC` field: instances filtered to `C_NPC`.
+  - `Dialog` field: instances + dialogs, filtered to `C_INFO` and prefix `DIA_`.
+- `VariableCondition`
+  - `Variable Name` filtered to `int|string|float`.
+- `NpcHasItemsCondition`
+  - `NPC` filtered to `C_NPC` instances.
+  - `Item` from instances (no explicit type filter).
+- `NpcIsInStateCondition`
+  - `NPC` filtered to `C_NPC` instances.
+- `NpcIsDeadCondition`
+  - `NPC` filtered to `C_NPC` instances.
+- `NpcGetDistToWpCondition`
+  - `NPC` filtered to `C_NPC` instances.
+- `NpcGetTalentSkillCondition`
+  - `NPC` filtered to `C_NPC` instances.
+
+Condition type not using autocomplete:
+
+- Generic `Condition` uses a plain text field.
+
+## Dialog properties section autocomplete mapping
+
+- Dialog `NPC` property uses instances filtered to `C_NPC`.
+- Dialog `Description` uses string symbols prefixed by `DIALOG_`.
+
+## Action renderer autocomplete mapping
+
+Autocomplete-enabled actions and field constraints:
+
+- `AttackActionRenderer`: attacker + target as `C_NPC` instances.
+- `CreateInventoryItemsRenderer`: NPC as `C_NPC`, item as `C_ITEM`.
+- `CreateTopicRenderer`: topic as `string` with prefix `TOPIC_`.
+- `ExchangeRoutineRenderer`: NPC as `C_NPC`.
+- `GiveInventoryItemsRenderer`: source NPC `C_NPC`, target NPC `C_NPC`, item `C_ITEM`.
+- `LogEntryRenderer`: topic as `string` with prefix `TOPIC_`.
+- `LogSetTopicStatusRenderer`: topic as `string` with prefix `TOPIC_`.
+- `PlayAniActionRenderer`: NPC as `C_NPC`.
+- `SetAttitudeActionRenderer`: NPC as `C_NPC`, attitude as `int`.
+- `SetVariableActionRenderer`: variable as `int|string|float`.
+- `StopProcessInfosActionRenderer`: NPC as `C_NPC` (without `showInstances`, so it resolves from symbol tables only).
+
+## Project mode dependency
+
+In project mode, autocomplete quality depends on merged model composition:
+
+- When selecting an NPC, the app parses NPC dialog files and merges only:
+  - that NPC's files, plus
+  - global files not tied to any NPC dialogs.
+
+So autocomplete options can differ per selected NPC in project mode.


### PR DESCRIPTION
### Motivation

- Provide a single reference explaining how `VariableAutocomplete` builds suggestion lists and which editor fields enable autocomplete so maintainers can debug, extend, and reason about suggestion behavior across the editor.

### Description

- Add `docs/AUTOCOMPLETE_FIELDS_INVESTIGATION.md` that documents core `VariableAutocomplete` behavior (sources: local/merged constants & variables, optional `instances`, optional `dialogs`), filtering rules (`typeFilter`, `namePrefix`), de-duplication, large-list UX thresholds, and the follow-reference navigation behavior.
- Enumerate where autocomplete is used (condition editor `ConditionCard`, dialog properties, and action renderers) and list per-field constraints (e.g. `C_NPC`, `C_ITEM`, `TOPIC_`/`DIA_` prefixes, numeric/string type filters) and explain how project-mode model merging can change available suggestions per selected NPC.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eed22371483328d90a3048931557e)