### PR TITLE
ci: grant PR read permissions for paths filter

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -13,6 +13,10 @@ on:
   pull_request:
     branches: [main,master]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- The `dorny/paths-filter@v3` step failed on pull request runs with `Resource not accessible by integration` because the workflow token did not have permission to read PR files.

### Description
- Add a top-level `permissions` block to `.github/workflows/all-tests.yml` granting `contents: read` and `pull-requests: read` so the paths filter can list changed files on PR events.

### Testing
- Validated the change by inspecting the workflow diff and file contents with `git diff -- .github/workflows/all-tests.yml`, `git show --stat --oneline HEAD`, and `nl -ba .github/workflows/all-tests.yml | sed -n '1,40p'`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ee2c428508332ab3efaa188d7dda0)