### PR TITLE
Fix late info-function action mirroring in parser linking visitor

### DIFF
--- a/daedalus-parser/test/preserve-if-actions.test.js
+++ b/daedalus-parser/test/preserve-if-actions.test.js
@@ -24,3 +24,31 @@ test('preserves if statements as raw actions in non-condition functions', () => 
   const hasDialogLine = func.actions.some(a => a.constructor.name === 'DialogLine');
   assert.equal(hasDialogLine, false, 'Should not flatten inner AI_Output into DialogLine actions');
 });
+
+
+test('mirrors preserved raw actions to dialog when info function is declared before instance', () => {
+  const source = `
+  func void DIA_Test_Info()
+  {
+    if (SC_IsRanger == TRUE)
+    {
+      AI_Output(self, other, "DIA_Test_01");
+    };
+  };
+
+  instance DIA_Test(C_INFO)
+  {
+    information = DIA_Test_Info;
+  };
+  `;
+
+  const model = parseSemanticModel(source);
+  const func = model.functions.DIA_Test_Info;
+  const dialog = model.dialogs.DIA_Test;
+  assert.ok(func, 'Info function should be parsed');
+  assert.ok(dialog, 'Dialog should be parsed');
+
+  assert.equal(func.actions.length, 1, 'Function should contain one preserved raw action');
+  assert.equal(dialog.actions.length, 1, 'Dialog should mirror function raw action even with late mapping');
+  assert.equal(dialog.actions[0].action, func.actions[0].action, 'Mirrored dialog action should match function action text');
+});


### PR DESCRIPTION
### Motivation
- Address inconsistent action propagation uncovered by the parser code review so preserved raw statements always use the centralized action recording path. 
- Ensure dialogs mirror preserved info-function actions even when the function declaration appears before the instance declaration. 
- Make dialog lookup for info-functions more resilient to different `information` property shapes to avoid missed mappings.

### Description
- Replaced direct mutation of `currentFunction.actions` in `preserveConditionStatement` with the shared `recordActionForCurrentFunction` call to centralize propagation behavior in `daedalus-parser/src/semantic/visitors/linking-visitor.ts`. 
- Added `syncDialogActionsForFunction(functionName, dialog)` and call it when an instance assigns `information = <func>` so existing function-level preserved actions are mirrored into the dialog (deduplicated). 
- Hardened `findDialogForFunction` to inspect `dialog.properties.information` (string or object form), cache the mapping in `functionToDialog`, and fall back to scanning dialogs when the map misses. 
- Added a regression test `test('mirrors preserved raw actions to dialog when info function is declared before instance', ...)` in `daedalus-parser/test/preserve-if-actions.test.js` which asserts dialog action mirroring for late-bound instances.

### Testing
- Built TypeScript artifacts with `npm run build:ts` in the `daedalus-parser` workspace and the build completed successfully. 
- Ran the parser test subset with `node --test test/preserve-if-actions.test.js test/condition-raw-fallback.test.js` and all tests passed (including the new regression), with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eef0d319083329a992a4409a8093c)