### PR TITLE
parser: type `parseDaedalusSource` return value in parser-utils

### DIFF
--- a/daedalus-parser/src/utils/parser-utils.ts
+++ b/daedalus-parser/src/utils/parser-utils.ts
@@ -4,7 +4,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import DaedalusParser from '../core/parser';
 import { SemanticModelBuilderVisitor } from '../semantic/semantic-visitor';
-import { SemanticModel } from '../semantic/semantic-model';
+import { SemanticModel, TreeSitterNode } from '../semantic/semantic-model';
+
+interface ParsedTree {
+  rootNode: TreeSitterNode;
+}
 
 /**
  * Create and configure a Daedalus parser instance
@@ -19,7 +23,7 @@ export function createDaedalusParser(): DaedalusParser {
  * @param sourceCode - Daedalus source code to parse
  * @returns Parse tree
  */
-export function parseDaedalusSource(sourceCode: string): any {
+export function parseDaedalusSource(sourceCode: string): ParsedTree {
   return DaedalusParser.parseSource(sourceCode).tree;
 }
 
@@ -30,7 +34,7 @@ export function parseDaedalusSource(sourceCode: string): any {
  */
 export function parseSemanticModel(sourceCode: string): SemanticModel {
   const parseResult = DaedalusParser.parseSource(sourceCode);
-  const tree = parseResult.tree;
+  const tree = parseResult.tree as ParsedTree;
 
   const visitor = new SemanticModelBuilderVisitor();
 


### PR DESCRIPTION
### Motivation
- Address a parser code-review follow-up by removing the remaining `any` typing on the central parser utility return value to reduce API drift and improve type safety.

### Description
- Added a local `ParsedTree` interface and imported `TreeSitterNode` from `semantic-model`, changed `parseDaedalusSource` to return `ParsedTree`, and cast `parseResult.tree` to `ParsedTree` so `parseSemanticModel` uses a typed `rootNode`.

### Testing
- Ran the TypeScript typecheck in `daedalus-parser` with `npm run typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f9b45dbf88332aa22e30548bad1f9)