### PR TITLE
Add semantic parsing buckets for NPCs and animations

### DIFF
--- a/daedalus-dialog-editor/src/shared/types.ts
+++ b/daedalus-dialog-editor/src/shared/types.ts
@@ -383,6 +383,8 @@ export interface SemanticModel {
   variables?: Record<string, GlobalVariable>;
   instances?: Record<string, GlobalInstance>;
   items?: Record<string, GlobalInstance>;
+  npcs?: Record<string, GlobalInstance>;
+  animations?: Record<string, GlobalInstance>;
   hasErrors: boolean;
   errors: ParseError[];
 }

--- a/daedalus-parser/src/semantic/visitors/declaration-visitor.ts
+++ b/daedalus-parser/src/semantic/visitors/declaration-visitor.ts
@@ -123,6 +123,20 @@ export class DeclarationVisitor {
             }
             this.semanticModel.items[instance.name] = instance;
           }
+
+          if (upperParent === 'C_NPC') {
+            if (!this.semanticModel.npcs) {
+              this.semanticModel.npcs = {};
+            }
+            this.semanticModel.npcs[instance.name] = instance;
+          }
+
+          if (upperParent === 'C_MDS') {
+            if (!this.semanticModel.animations) {
+              this.semanticModel.animations = {};
+            }
+            this.semanticModel.animations[instance.name] = instance;
+          }
         }
       }
       return; // Optimization: Don't recurse into instance bodies during object creation

--- a/daedalus-parser/test/semantic-global-symbols.test.js
+++ b/daedalus-parser/test/semantic-global-symbols.test.js
@@ -87,6 +87,10 @@ test('should parse non-dialog instances into semantic model instances', () => {
     {
       name = "Rusty Sword";
     };
+
+    INSTANCE HUMANS_MDS(C_MDS)
+    {
+    };
   `;
 
   const model = parseSemanticModel(source);
@@ -110,4 +114,15 @@ test('should parse non-dialog instances into semantic model instances', () => {
   assert.equal(model.items['ITMI_SWORD'].parent, 'C_ITEM');
   assert.equal(model.items['ITMI_SWORD'].displayName, 'Rusty Sword');
   assert.equal(model.items['SLD_200_DIEGO'], undefined, 'Non-item instances should not be in items map');
+
+
+  assert.ok(model.npcs, 'Model should have npcs map');
+  assert.ok(model.npcs['SLD_200_DIEGO'], 'Should include npc instance in npcs map');
+  assert.equal(model.npcs['SLD_200_DIEGO'].parent, 'C_NPC');
+  assert.equal(model.npcs['ITMI_SWORD'], undefined, 'Non-npc instances should not be in npcs map');
+
+  assert.ok(model.animations, 'Model should have animations map');
+  assert.ok(model.animations['HUMANS_MDS'], 'Should include animation instance in animations map');
+  assert.equal(model.animations['HUMANS_MDS'].parent, 'C_MDS');
+  assert.equal(model.animations['SLD_200_DIEGO'], undefined, 'Non-animation instances should not be in animations map');
 });


### PR DESCRIPTION
### Motivation
- Provide first-class semantic buckets for non-dialog instance categories so downstream tooling (autocomplete, editor UI) can look up NPC and animation instances directly instead of scanning a flat `instances` map.
- Preserve backward compatibility for older serialized models while enabling explicit `npcs` and `animations` maps for newer consumers.
- Keep existing behavior for items (armor remains a `C_ITEM`) while expanding categorical coverage to `C_NPC` and `C_MDS`/animation instances.

### Description
- Added `npcs` and `animations` maps to the parser-side `SemanticModel` interface in `daedalus-parser/src/semantic/semantic-model.ts` and to the editor shared `SemanticModel` type in `daedalus-dialog-editor/src/shared/types.ts`.
- Updated the `DeclarationVisitor` to populate `semanticModel.npcs` for `C_NPC` instances and `semanticModel.animations` for `C_MDS` instances during instance declaration visitation (`daedalus-parser/src/semantic/visitors/declaration-visitor.ts`).
- Extended `deserializeSemanticModel` to reconstruct `npcs`/`animations` from JSON and to backfill `items`, `npcs`, and `animations` by deriving from `instances` when those categorized maps are absent.
- Expanded `daedalus-parser/test/semantic-global-symbols.test.js` to assert the new `npcs` and `animations` buckets and added a fixture `HUMANS_MDS` animation instance for coverage.

### Testing
- Ran `npm test` in `daedalus-parser` which builds and runs the test suite; all tests passed (`# tests 123`, `# pass 123`, `# fail 0`).
- Ran `npm run build:main` in `daedalus-dialog-editor` to typecheck/build editor main code; the build succeeded with no TypeScript errors.
- Updated files were committed and validated in local CI steps described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991a967e0a08332a7aec3e80b0c203f)