### PR TITLE
Modernize MUI look-and-feel across light/dark themes

### DIFF
--- a/daedalus-dialog-editor/src/renderer/theme.ts
+++ b/daedalus-dialog-editor/src/renderer/theme.ts
@@ -1,9 +1,43 @@
-import { createTheme, Theme } from '@mui/material/styles';
+import { alpha, createTheme, Theme } from '@mui/material/styles';
 
 export type ThemeMode = 'dark' | 'light' | 'gothic';
 
 const sharedShape = {
-  borderRadius: 8,
+  borderRadius: 12,
+};
+
+const sharedComponents = {
+  MuiPaper: {
+    defaultProps: {
+      elevation: 0,
+    },
+    styleOverrides: {
+      root: {
+        backgroundImage: 'none',
+        border: '1px solid',
+      },
+    },
+  },
+  MuiButton: {
+    defaultProps: {
+      disableElevation: true,
+    },
+    styleOverrides: {
+      root: {
+        borderRadius: 999,
+        textTransform: 'none' as const,
+        fontWeight: 600,
+        paddingInline: 16,
+      },
+    },
+  },
+  MuiChip: {
+    styleOverrides: {
+      root: {
+        borderRadius: 999,
+      },
+    },
+  },
 };
 
 const gothicTheme = createTheme({
@@ -44,6 +78,7 @@ const gothicTheme = createTheme({
     },
   },
   components: {
+    ...sharedComponents,
     MuiAppBar: {
       styleOverrides: {
         root: {
@@ -55,8 +90,8 @@ const gothicTheme = createTheme({
     MuiPaper: {
       styleOverrides: {
         root: {
+          borderColor: 'rgba(200, 162, 90, 0.14)',
           backgroundImage: 'linear-gradient(180deg, rgba(255,255,255,0.02) 0%, rgba(0,0,0,0.18) 100%)',
-          border: '1px solid rgba(200, 162, 90, 0.14)',
         },
       },
     },
@@ -74,30 +109,99 @@ const darkTheme = createTheme({
   palette: {
     mode: 'dark',
     primary: {
-      main: '#90caf9',
+      main: '#7dd3fc',
+      light: '#bae6fd',
+      dark: '#0ea5e9',
+      contrastText: '#031621',
     },
     secondary: {
-      main: '#f48fb1',
+      main: '#c4b5fd',
+    },
+    background: {
+      default: '#090b10',
+      paper: '#111521',
+    },
+    divider: alpha('#94a3b8', 0.18),
+    text: {
+      primary: '#e5ecff',
+      secondary: '#9aa8c5',
     },
   },
   shape: sharedShape,
+  typography: {
+    fontFamily: '"Inter", "Segoe UI", "Roboto", sans-serif',
+    h6: {
+      fontWeight: 700,
+      letterSpacing: '-0.01em',
+    },
+  },
+  components: {
+    ...sharedComponents,
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'linear-gradient(110deg, #111827 0%, #0f172a 45%, #111827 100%)',
+          borderBottom: `1px solid ${alpha('#7dd3fc', 0.22)}`,
+          boxShadow: '0 14px 35px rgba(2, 6, 23, 0.45)',
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderColor: alpha('#94a3b8', 0.18),
+          boxShadow: '0 12px 30px rgba(2, 6, 23, 0.2)',
+        },
+      },
+    },
+  },
 });
 
 const lightTheme = createTheme({
   palette: {
     mode: 'light',
     primary: {
-      main: '#1565c0',
+      main: '#2563eb',
+      light: '#60a5fa',
+      dark: '#1d4ed8',
     },
     secondary: {
-      main: '#8e24aa',
+      main: '#7c3aed',
     },
     background: {
-      default: '#f4f6fb',
+      default: '#f3f6ff',
       paper: '#ffffff',
     },
+    divider: alpha('#475569', 0.16),
   },
   shape: sharedShape,
+  typography: {
+    fontFamily: '"Inter", "Segoe UI", "Roboto", sans-serif',
+    h6: {
+      fontWeight: 700,
+      letterSpacing: '-0.01em',
+    },
+  },
+  components: {
+    ...sharedComponents,
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'linear-gradient(110deg, #2563eb 0%, #1d4ed8 60%, #312e81 100%)',
+          borderBottom: `1px solid ${alpha('#ffffff', 0.26)}`,
+          boxShadow: '0 12px 30px rgba(37, 99, 235, 0.28)',
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderColor: alpha('#94a3b8', 0.22),
+          boxShadow: '0 12px 28px rgba(15, 23, 42, 0.08)',
+        },
+      },
+    },
+  },
 });
 
 export const themes: Record<ThemeMode, Theme> = {


### PR DESCRIPTION
### Motivation
- The app's MUI appearance was looking dated and should feel fresher and more consistent across themes. 
- Provide a small set of global component defaults so controls look modern (pill buttons/chips, subtle paper borders) without touching every component. 
- Preserve the existing Gothic theme identity while bringing the same modern baseline to dark/light modes.

### Description
- Increased global `borderRadius` and added `sharedComponents` defaults for `MuiPaper`, `MuiButton`, and `MuiChip` to produce flatter, pill-shaped controls and subtle bordered surfaces in `daedalus-dialog-editor/src/renderer/theme.ts`.
- Applied `...sharedComponents` to the `gothic` theme so it retains its look but benefits from the updated controls.
- Redesigned the `dark` theme palette, typography, app bar gradient, divider/text tuning and added subtle shadows/box-shadows for depth.
- Redesigned the `light` theme palette, typography and app bar gradient and added matching paper/divider treatment for visual parity with dark mode.

### Testing
- Built the renderer with `npm run build --workspace daedalus-dialog-editor` and the build completed successfully.
- Launched the renderer in browser dev mode with `npm run dev:browser --workspace daedalus-dialog-editor -- --host 0.0.0.0 --port 4173` and the dev server started successfully.
- Captured a visual verification screenshot via Playwright of the running renderer and inspected the updated UI (screenshot captured during the run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699209fd55588332aa9ef482c4ba3785)