### PR TITLE
Introduce quest domain/application layers and route QuestFlow commands through QuestEditingService

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/QuestFlow.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestFlow.tsx
@@ -30,15 +30,15 @@ import type { QuestGraphBuildOptions, QuestGraphEdge, QuestGraphNode } from '../
 import { useNavigation } from '../hooks/useNavigation';
 import { useEditorStore } from '../store/editorStore';
 import { useProjectStore } from '../store/projectStore';
-import { buildQuestGraph } from './QuestEditor/questGraphUtils';
-import { findDialogNameForFunction } from './QuestEditor/questAnalysis';
 import {
   analyzeQuestGuardrails,
+  buildQuestGraph,
+  findDialogNameForFunction,
   getQuestGuardrailDeltaWarnings,
-  isQuestGuardrailWarningBlocking
-} from './QuestEditor/questGuardrails';
-import { executeQuestGraphCommand } from './QuestEditor/commands';
-import type { QuestGraphCommand } from './QuestEditor/commands';
+  isQuestGuardrailWarningBlocking,
+  type QuestGraphCommand
+} from '../quest/domain';
+import { QuestEditingService } from '../quest/application';
 import DialogNode from './QuestEditor/Nodes/DialogNode';
 import QuestStateNode from './QuestEditor/Nodes/QuestStateNode';
 import ConditionNode from './QuestEditor/Nodes/ConditionNode';
@@ -373,7 +373,7 @@ const QuestFlow: React.FC<QuestFlowProps> = ({ semanticModel, questName, writabl
         return;
       }
 
-      const commandResult = executeQuestGraphCommand(
+      const commandResult = QuestEditingService.runCommand(
         {
           questName,
           model: fileState.semanticModel
@@ -434,7 +434,7 @@ const QuestFlow: React.FC<QuestFlowProps> = ({ semanticModel, questName, writabl
         return;
       }
 
-      const sourceResult = executeQuestGraphCommand(
+      const sourceResult = QuestEditingService.runCommand(
         { questName, model: sourceState.semanticModel },
         {
           type: 'connectCondition',
@@ -454,7 +454,7 @@ const QuestFlow: React.FC<QuestFlowProps> = ({ semanticModel, questName, writabl
       if (sourceFilePath !== targetFilePath) {
         const sourceDialogName = findDialogNameForFunction(semanticModel, sourceFunctionName);
         if (sourceDialogName) {
-          const targetResult = executeQuestGraphCommand(
+          const targetResult = QuestEditingService.runCommand(
             { questName, model: targetState.semanticModel },
             {
               type: 'addKnowsInfoRequirement',
@@ -508,7 +508,7 @@ const QuestFlow: React.FC<QuestFlowProps> = ({ semanticModel, questName, writabl
         return;
       }
 
-      const sourceResult = executeQuestGraphCommand(
+      const sourceResult = QuestEditingService.runCommand(
         { questName, model: sourceState.semanticModel },
         {
           type: 'removeTransition',
@@ -527,7 +527,7 @@ const QuestFlow: React.FC<QuestFlowProps> = ({ semanticModel, questName, writabl
       if (sourceFilePath !== targetFilePath) {
         const sourceDialogName = findDialogNameForFunction(semanticModel, sourceFunctionName);
         if (sourceDialogName) {
-          const targetResult = executeQuestGraphCommand(
+          const targetResult = QuestEditingService.runCommand(
             { questName, model: targetState.semanticModel },
             {
               type: 'removeKnowsInfoRequirement',
@@ -582,7 +582,7 @@ const QuestFlow: React.FC<QuestFlowProps> = ({ semanticModel, questName, writabl
         return;
       }
 
-      const sourceResult = executeQuestGraphCommand(
+      const sourceResult = QuestEditingService.runCommand(
         { questName, model: sourceState.semanticModel },
         {
           type: 'updateTransitionText',
@@ -601,7 +601,7 @@ const QuestFlow: React.FC<QuestFlowProps> = ({ semanticModel, questName, writabl
       if (sourceFilePath !== targetFilePath) {
         const sourceDialogName = findDialogNameForFunction(semanticModel, sourceFunctionName);
         if (sourceDialogName) {
-          const targetResult = executeQuestGraphCommand(
+          const targetResult = QuestEditingService.runCommand(
             { questName, model: targetState.semanticModel },
             {
               type: 'addKnowsInfoRequirement',

--- a/daedalus-dialog-editor/src/renderer/quest/application/QuestEditingService.ts
+++ b/daedalus-dialog-editor/src/renderer/quest/application/QuestEditingService.ts
@@ -1,0 +1,14 @@
+import type { SemanticModel } from '../../types/global';
+import * as questCommands from '../domain/commands';
+import type { QuestGraphCommand } from '../domain/commands';
+
+export interface QuestCommandContext {
+  questName: string;
+  model: SemanticModel;
+}
+
+export const QuestEditingService = {
+  runCommand(context: QuestCommandContext, command: QuestGraphCommand) {
+    return questCommands.executeQuestGraphCommand(context, command);
+  }
+};

--- a/daedalus-dialog-editor/src/renderer/quest/application/index.ts
+++ b/daedalus-dialog-editor/src/renderer/quest/application/index.ts
@@ -1,0 +1,2 @@
+export { QuestEditingService } from './QuestEditingService';
+export type { QuestCommandContext } from './QuestEditingService';

--- a/daedalus-dialog-editor/src/renderer/quest/domain/analysis.ts
+++ b/daedalus-dialog-editor/src/renderer/quest/domain/analysis.ts
@@ -1,0 +1,6 @@
+export {
+  analyzeQuest,
+  findDialogNameForFunction,
+  getQuestReferences,
+  getUsedQuestTopics
+} from '../../components/QuestEditor/questAnalysis';

--- a/daedalus-dialog-editor/src/renderer/quest/domain/commands.ts
+++ b/daedalus-dialog-editor/src/renderer/quest/domain/commands.ts
@@ -1,0 +1,2 @@
+export { executeQuestGraphCommand } from '../../components/QuestEditor/commands';
+export type { QuestGraphCommand } from '../../components/QuestEditor/commands';

--- a/daedalus-dialog-editor/src/renderer/quest/domain/graph.ts
+++ b/daedalus-dialog-editor/src/renderer/quest/domain/graph.ts
@@ -1,0 +1,1 @@
+export { buildQuestGraph } from '../../components/QuestEditor/questGraphUtils';

--- a/daedalus-dialog-editor/src/renderer/quest/domain/guardrails.ts
+++ b/daedalus-dialog-editor/src/renderer/quest/domain/guardrails.ts
@@ -1,0 +1,6 @@
+export {
+  analyzeQuestGuardrails,
+  getNewQuestGuardrailWarnings,
+  getQuestGuardrailDeltaWarnings,
+  isQuestGuardrailWarningBlocking
+} from '../../components/QuestEditor/questGuardrails';

--- a/daedalus-dialog-editor/src/renderer/quest/domain/index.ts
+++ b/daedalus-dialog-editor/src/renderer/quest/domain/index.ts
@@ -1,0 +1,4 @@
+export * from './analysis';
+export * from './commands';
+export * from './graph';
+export * from './guardrails';

--- a/daedalus-dialog-editor/tests/QuestFlow.commandPreview.test.tsx
+++ b/daedalus-dialog-editor/tests/QuestFlow.commandPreview.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import QuestFlow from '../src/renderer/components/QuestFlow';
-import * as questCommands from '../src/renderer/components/QuestEditor/commands';
+import * as questCommands from '../src/renderer/quest/domain/commands';
 import type { SemanticModel } from '../src/renderer/types/global';
 
 jest.mock('reactflow', () => {
@@ -92,7 +92,7 @@ jest.mock('reactflow', () => {
   };
 });
 
-jest.mock('../src/renderer/components/QuestEditor/questGraphUtils', () => ({
+jest.mock('../src/renderer/quest/domain/graph', () => ({
   buildQuestGraph: () => ({
     nodes: [
       {

--- a/daedalus-dialog-editor/tests/QuestFlow.ui.test.tsx
+++ b/daedalus-dialog-editor/tests/QuestFlow.ui.test.tsx
@@ -16,7 +16,7 @@ jest.mock('reactflow', () => {
   };
 });
 
-jest.mock('../src/renderer/components/QuestEditor/questGraphUtils', () => ({
+jest.mock('../src/renderer/quest/domain/graph', () => ({
   buildQuestGraph: () => ({ nodes: [], edges: [] })
 }));
 

--- a/daedalus-dialog-editor/tests/questAnalysis.test.ts
+++ b/daedalus-dialog-editor/tests/questAnalysis.test.ts
@@ -1,4 +1,4 @@
-import { analyzeQuest, getQuestReferences, getUsedQuestTopics, findDialogNameForFunction } from '../src/renderer/components/QuestEditor/questAnalysis';
+import { analyzeQuest, getQuestReferences, getUsedQuestTopics, findDialogNameForFunction } from '../src/renderer/quest/domain/analysis';
 import type { SemanticModel } from '../src/renderer/types/global';
 import { isQuestTopicConstantByPolicy } from '../src/renderer/utils/questIdentity';
 

--- a/daedalus-dialog-editor/tests/questCommands.regression.test.ts
+++ b/daedalus-dialog-editor/tests/questCommands.regression.test.ts
@@ -1,4 +1,4 @@
-import { executeQuestGraphCommand } from '../src/renderer/components/QuestEditor/commands';
+import { executeQuestGraphCommand } from '../src/renderer/quest/domain/commands';
 import type { SemanticModel } from '../src/renderer/types/global';
 
 const createBranchHeavyModel = (): SemanticModel => ({

--- a/daedalus-dialog-editor/tests/questCommands.setMisState.test.ts
+++ b/daedalus-dialog-editor/tests/questCommands.setMisState.test.ts
@@ -1,4 +1,4 @@
-import { executeQuestGraphCommand } from '../src/renderer/components/QuestEditor/commands';
+import { executeQuestGraphCommand } from '../src/renderer/quest/domain/commands';
 import type { SemanticModel } from '../src/renderer/types/global';
 
 const createModel = (): SemanticModel => ({

--- a/daedalus-dialog-editor/tests/questGraphUtils.test.tsx
+++ b/daedalus-dialog-editor/tests/questGraphUtils.test.tsx
@@ -1,4 +1,4 @@
-import { buildQuestGraph } from '../src/renderer/components/QuestEditor/questGraphUtils';
+import { buildQuestGraph } from '../src/renderer/quest/domain/graph';
 import type { SemanticModel } from '../src/renderer/types/global';
 
 // Mock Semantic Model Helper

--- a/daedalus-dialog-editor/tests/questGraphUtils.variableDependency.test.tsx
+++ b/daedalus-dialog-editor/tests/questGraphUtils.variableDependency.test.tsx
@@ -1,4 +1,4 @@
-import { buildQuestGraph } from '../src/renderer/components/QuestEditor/questGraphUtils';
+import { buildQuestGraph } from '../src/renderer/quest/domain/graph';
 import type { SemanticModel } from '../src/renderer/types/global';
 
 // Mock Semantic Model Helper (Reused from questGraphUtils.test.tsx)

--- a/daedalus-dialog-editor/tests/questGuardrails.regression.test.ts
+++ b/daedalus-dialog-editor/tests/questGuardrails.regression.test.ts
@@ -1,4 +1,4 @@
-import { analyzeQuestGuardrails, getQuestGuardrailDeltaWarnings } from '../src/renderer/components/QuestEditor/questGuardrails';
+import { analyzeQuestGuardrails, getQuestGuardrailDeltaWarnings } from '../src/renderer/quest/domain/guardrails';
 import type { SemanticModel } from '../src/renderer/types/global';
 
 const createBaseMdkLikeModel = (): SemanticModel => ({

--- a/daedalus-dialog-editor/tests/questGuardrails.test.ts
+++ b/daedalus-dialog-editor/tests/questGuardrails.test.ts
@@ -3,7 +3,7 @@ import {
   getQuestGuardrailDeltaWarnings,
   getNewQuestGuardrailWarnings,
   isQuestGuardrailWarningBlocking
-} from '../src/renderer/components/QuestEditor/questGuardrails';
+} from '../src/renderer/quest/domain/guardrails';
 import type { SemanticModel } from '../src/renderer/types/global';
 
 const createModel = (functions: Record<string, any>): SemanticModel => ({

--- a/docs/QUEST_EDITOR_BOUNDARIES.md
+++ b/docs/QUEST_EDITOR_BOUNDARIES.md
@@ -1,0 +1,95 @@
+# Quest Editor Internal Boundary Plan (Monorepo)
+
+## Decision
+
+Keep the node-based quest editor in the current monorepo and enforce stronger internal module boundaries instead of splitting to a new repository.
+
+## Goals
+
+1. Preserve fast iteration between parser/editor/graph UX.
+2. Reduce coupling between quest domain logic and React/Electron UI code.
+3. Make future extraction possible with low migration cost.
+
+## Target module boundaries
+
+### 1) `quest-domain` (pure logic, no UI)
+
+**Contains:**
+- quest graph model building and transforms
+- command validation/execution
+- guardrail checks
+- deterministic diff-generation helpers (data-level)
+
+**Must not import:**
+- React / ReactFlow / MUI
+- renderer store hooks
+- Electron APIs
+
+### 2) `quest-application` (state orchestration)
+
+**Contains:**
+- editor store integration adapters
+- transaction history wiring (undo/redo)
+- autosave and apply/cancel orchestration
+
+**May import:**
+- `quest-domain`
+- project/editor store contracts
+
+**Must not import:**
+- visual node components
+
+### 3) `quest-ui` (renderer view layer)
+
+**Contains:**
+- `QuestFlow` and node components
+- inspector forms and local UI behavior
+- feature-flag driven UX toggles
+
+**May import:**
+- `quest-application` interfaces only
+
+**Must not contain:**
+- direct semantic model mutations
+- core validation/business rules
+
+## Repo-local implementation conventions
+
+1. Place domain/application code under:
+   - `daedalus-dialog-editor/src/renderer/quest/domain/*`
+   - `daedalus-dialog-editor/src/renderer/quest/application/*`
+2. Keep UI-specific code under:
+   - `daedalus-dialog-editor/src/renderer/components/QuestEditor/*`
+3. Restrict imports by convention:
+   - `components/QuestEditor/*` can depend on `quest/application`.
+   - `quest/domain/*` cannot depend on `components/*`.
+4. Add barrel exports per layer to keep import surfaces intentional.
+
+## Near-term migration slices
+
+### Slice A: Stabilize domain entry points
+- Move command types + validators into `quest/domain/commands/*`.
+- Move guardrail analysis into `quest/domain/guardrails/*`.
+- Keep behavior unchanged; verify with existing quest command/guardrail tests.
+
+### Slice B: Introduce application service facade
+- Add `QuestEditingService` in `quest/application` for:
+  - `runCommand`
+  - `previewChanges`
+  - `applyPreview`
+  - `undo` / `redo`
+- Convert `QuestFlow` to call service methods instead of touching stores directly.
+
+### Slice C: Tighten dependency checks
+- Add lint/import rules (or CI grep checks) blocking forbidden cross-layer imports.
+- Enforce all new quest edits through the command pipeline.
+
+## Exit criteria
+
+This boundary hardening is complete when:
+
+1. Quest business rules are testable without rendering React components.
+2. `QuestFlow` has no direct semantic mutation logic.
+3. Import restrictions prevent UI->domain circular coupling.
+4. Extracting `quest-domain` to a package is mostly path rewrites and build config.
+


### PR DESCRIPTION
### Motivation

- Separate pure quest logic from UI code to reduce coupling and make domain logic extractable and testable.
- Provide a small application facade to centralize command execution and prepare for higher-level orchestration (undo/redo, preview/apply).

### Description

- Add a new `quest/domain` layer with barrel exports and files for `commands`, `graph`, `guardrails`, and `analysis` that re-export existing pure logic from `components/QuestEditor` paths.
- Add a new `quest/application/QuestEditingService` facade and index that exposes `runCommand` and wraps the domain command execution API.
- Update `QuestFlow.tsx` to import domain helpers from `../quest/domain` and to use `QuestEditingService.runCommand` instead of calling `executeQuestGraphCommand` directly, and adjust related type imports.
- Update tests and mocks to point at the new domain/application entry points and adjust graph mocks accordingly, and add `docs/QUEST_EDITOR_BOUNDARIES.md` describing the intended modular boundaries and migration plan.

### Testing

- Ran the updated unit tests that exercise command execution, graph building, guardrail analysis, and UI flows including `QuestFlow.*` and `quest*` tests; all affected tests passed locally (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1690d8b8483328049b00273a82dc0)