### PR TITLE
Fix Windows electron-builder pnpm execpath in packaging workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,6 +31,8 @@ jobs:
       run: pnpm --filter daedalus-dialog-editor run build
 
     - name: Package Editor
+      env:
+        npm_execpath: pnpm
       run: pnpm --filter daedalus-dialog-editor run package
 
     - name: Upload Artifacts


### PR DESCRIPTION
### Motivation
- On Windows CI `electron-builder` was attempting to fork/exec the `pnpm.cjs` script and failing with `%1 is not a valid Win32 application`, so the packaging step must force the package manager to resolve via the `pnpm` command name.

### Description
- Set `npm_execpath: pnpm` in the `Package Editor` step of `.github/workflows/build-windows.yml` so `electron-builder` uses the `pnpm` executable on PATH instead of the `.cjs` script.

### Testing
- No automated tests were run locally; the change is small and the Windows GitHub Actions job will validate packaging success when the workflow runs in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a188c672e8833290abb8018a221ffd)