### PR TITLE
fix(editor): skip electron-builder pnpm native rebuild

### DIFF
--- a/daedalus-dialog-editor/package.json
+++ b/daedalus-dialog-editor/package.json
@@ -51,7 +51,8 @@
     "win": {
       "target": "nsis"
     },
-    "publish": null
+    "publish": null,
+    "npmRebuild": false
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",


### PR DESCRIPTION
### Motivation
- Prevent electron-builder from invoking `pnpm` to rebuild native dependencies on Windows CI, which caused `%1 is not a valid Win32 application` when attempting to execute `pnpm.cjs`.

### Description
- Set `build.npmRebuild` to `false` in `daedalus-dialog-editor/package.json` to skip electron-builder's automatic dependency rebuild phase.

### Testing
- Ran `pnpm --filter daedalus-dialog-editor run package` which confirms `skipped dependencies rebuild  reason=npmRebuild is set to false` but packaging then fails on an unrelated missing `dist/main/main.js` entry; ran `pnpm --filter daedalus-dialog-editor run build` which fails on a pre-existing Vite module resolution error for `litegraph.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a190d0dab48332b8543cf9b844d000)