### PR TITLE
Fix repository detection for GitHub Pages download link

### DIFF
--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -169,10 +169,45 @@
       const linkEl = document.getElementById('downloadLink');
       const repoPathEl = document.getElementById('repoPath');
 
-      const [owner, repo] = window.location.pathname
-        .split('/')
-        .filter(Boolean)
-        .slice(0, 2);
+      function detectRepoPath() {
+        const params = new URLSearchParams(window.location.search);
+        const ownerFromQuery = params.get('owner');
+        const repoFromQuery = params.get('repo');
+        const combinedFromQuery = params.get('repository') || params.get('repoPath');
+
+        if (ownerFromQuery && repoFromQuery) {
+          return { owner: ownerFromQuery, repo: repoFromQuery };
+        }
+
+        if (combinedFromQuery && combinedFromQuery.includes('/')) {
+          const [owner, repo] = combinedFromQuery.split('/').filter(Boolean).slice(0, 2);
+
+          if (owner && repo) {
+            return { owner, repo };
+          }
+        }
+
+        const pathParts = window.location.pathname.split('/').filter(Boolean);
+        const host = window.location.hostname.toLowerCase();
+
+        if (host.endsWith('.github.io')) {
+          const owner = host.split('.')[0];
+          const repo = pathParts.find(Boolean);
+
+          if (owner && repo) {
+            return { owner, repo };
+          }
+        }
+
+        if (pathParts.length >= 2) {
+          const [owner, repo] = pathParts;
+          return { owner, repo };
+        }
+
+        return { owner: null, repo: null };
+      }
+
+      const { owner, repo } = detectRepoPath();
 
       async function loadLatestWindowsBuild() {
         if (!owner || !repo) {


### PR DESCRIPTION
### Motivation
- The page could show "Could not detect repository path from URL." and "Download unavailable" because detection assumed both owner and repo were in the URL path. 
- Project GitHub Pages sites (e.g. `owner.github.io/repo/...`) place the owner in the hostname so the old logic failed to resolve the repo path.

### Description
- Replace the fragile pathname-only parsing with a new `detectRepoPath()` helper in `gh-pages/index.html` that centralizes repo detection logic.
- Add support for explicit query params (`?owner=...&repo=...`) and combined params (`?repository=owner/repo` or `?repoPath=owner/repo`).
- Detect owner/repo on `*.github.io` hosts by deriving the owner from the subdomain and the repo from the first path segment, and fall back to `/<owner>/<repo>/...` for other hosts.
- Preserve existing release-fetch behavior and API URL (`https://api.github.com/repos/<owner>/<repo>/releases/tags/windows-latest`) and the logic that selects the `.exe` asset.

### Testing
- Searched for the previous error messages with `rg` to locate the download script and confirm targets, and the search completed successfully.
- Inspected the updated HTML and script with `sed -n` and `nl -ba` to confirm the `detectRepoPath()` insertion and that the rest of the download logic is unchanged.
- Reviewed the generated patch and file content to ensure the new detection paths are covered and that the page will still construct the same GitHub API URL when detection succeeds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1db17a0288332a7e50240e4649770)