### PR TITLE
Add isolated browser node editor playground with rich mock quest data

### DIFF
--- a/daedalus-dialog-editor/package.json
+++ b/daedalus-dialog-editor/package.json
@@ -23,7 +23,8 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
-    "test:e2e:debug": "playwright test --debug"
+    "test:e2e:debug": "playwright test --debug",
+    "dev:node-editor": "vite --open /node-editor.html"
   },
   "keywords": [
     "gothic",

--- a/daedalus-dialog-editor/src/renderer/NodeEditorPlayground.tsx
+++ b/daedalus-dialog-editor/src/renderer/NodeEditorPlayground.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Box, FormControl, InputLabel, MenuItem, Paper, Select, Stack, Typography } from '@mui/material';
+import QuestFlow from './components/QuestFlow';
+import { nodeEditorMockModel, nodeEditorMockQuests } from './mocks/nodeEditorMockData';
+
+const NodeEditorPlayground: React.FC = () => {
+  const [selectedQuest, setSelectedQuest] = useState<string>(nodeEditorMockQuests[0]);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh', bgcolor: 'background.default' }}>
+      <Paper square elevation={1} sx={{ px: 2, py: 1.5, borderBottom: 1, borderColor: 'divider' }}>
+        <Stack direction="row" alignItems="center" spacing={2}>
+          <Box sx={{ flexGrow: 1 }}>
+            <Typography variant="h6">Quest Node Editor Playground</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Isolated browser playground with mock quest dialogs, conditions and transitions.
+            </Typography>
+          </Box>
+          <FormControl size="small" sx={{ minWidth: 260 }}>
+            <InputLabel id="node-editor-quest-select-label">Quest</InputLabel>
+            <Select
+              labelId="node-editor-quest-select-label"
+              value={selectedQuest}
+              label="Quest"
+              inputProps={{ 'data-testid': 'node-editor-quest-select' }}
+              onChange={(event) => setSelectedQuest(event.target.value)}
+            >
+              {nodeEditorMockQuests.map((questName) => (
+                <MenuItem key={questName} value={questName}>
+                  {questName}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Stack>
+      </Paper>
+
+      <Box sx={{ flexGrow: 1, minHeight: 0 }}>
+        <QuestFlow semanticModel={nodeEditorMockModel} questName={selectedQuest} writableEnabled={false} />
+      </Box>
+    </Box>
+  );
+};
+
+export default NodeEditorPlayground;

--- a/daedalus-dialog-editor/src/renderer/mocks/nodeEditorMockData.ts
+++ b/daedalus-dialog-editor/src/renderer/mocks/nodeEditorMockData.ts
@@ -1,0 +1,205 @@
+import type { SemanticModel } from '../types/global';
+
+export const nodeEditorMockModel: SemanticModel = {
+  dialogs: {
+    DIA_DragonHunt_Start: {
+      name: 'DIA_DragonHunt_Start',
+      parent: 'C_INFO',
+      properties: {
+        npc: 'DIA_NPC_GAROND',
+        nr: 100,
+        condition: 'DIA_DragonHunt_Start_Condition',
+        information: 'DIA_DragonHunt_Start_Info',
+        important: true,
+      },
+    },
+    DIA_DragonHunt_Investigate: {
+      name: 'DIA_DragonHunt_Investigate',
+      parent: 'C_INFO',
+      properties: {
+        npc: 'DIA_NPC_GAROND',
+        nr: 110,
+        condition: 'DIA_DragonHunt_Investigate_Condition',
+        information: 'DIA_DragonHunt_Investigate_Info',
+      },
+    },
+    DIA_DragonHunt_Complete: {
+      name: 'DIA_DragonHunt_Complete',
+      parent: 'C_INFO',
+      properties: {
+        npc: 'DIA_NPC_GAROND',
+        nr: 120,
+        condition: 'DIA_DragonHunt_Complete_Condition',
+        information: 'DIA_DragonHunt_Complete_Info',
+      },
+    },
+    DIA_DragonHunt_Fail: {
+      name: 'DIA_DragonHunt_Fail',
+      parent: 'C_INFO',
+      properties: {
+        npc: 'DIA_NPC_GAROND',
+        nr: 130,
+        condition: 'DIA_DragonHunt_Fail_Condition',
+        information: 'DIA_DragonHunt_Fail_Info',
+      },
+    },
+    DIA_GuildJoin_Start: {
+      name: 'DIA_GuildJoin_Start',
+      parent: 'C_INFO',
+      properties: {
+        npc: 'DIA_NPC_ANDRE',
+        nr: 200,
+        condition: 'DIA_GuildJoin_Start_Condition',
+        information: 'DIA_GuildJoin_Start_Info',
+      },
+    },
+    DIA_GuildJoin_Approve: {
+      name: 'DIA_GuildJoin_Approve',
+      parent: 'C_INFO',
+      properties: {
+        npc: 'DIA_NPC_ANDRE',
+        nr: 210,
+        condition: 'DIA_GuildJoin_Approve_Condition',
+        information: 'DIA_GuildJoin_Approve_Info',
+      },
+    },
+  },
+  functions: {
+    DIA_DragonHunt_Start_Condition: {
+      name: 'DIA_DragonHunt_Start_Condition',
+      returnType: 'INT',
+      conditions: [
+        { type: 'VariableCondition', variableName: 'MIS_DRAGONHUNT', operator: '==', value: 0, negated: false },
+        { type: 'NpcHasItemsCondition', npc: 'hero', item: 'ITMI_DRAGON_EGG', operator: '>=', value: 1 },
+      ],
+      actions: [],
+      calls: [],
+    },
+    DIA_DragonHunt_Start_Info: {
+      name: 'DIA_DragonHunt_Start_Info',
+      returnType: 'VOID',
+      conditions: [],
+      actions: [
+        { type: 'DialogLine', speaker: 'self', text: 'Bring me proof you found the dragons.', id: 'DIA_DragonHunt_Start_15_00' },
+        { type: 'CreateTopic', topic: 'TOPIC_DRAGONHUNT', topicType: 'LOG_MISSION' },
+        { type: 'LogSetTopicStatus', topic: 'TOPIC_DRAGONHUNT', status: 'LOG_RUNNING' },
+      ],
+      calls: [],
+    },
+    DIA_DragonHunt_Investigate_Condition: {
+      name: 'DIA_DragonHunt_Investigate_Condition',
+      returnType: 'INT',
+      conditions: [
+        { type: 'VariableCondition', variableName: 'MIS_DRAGONHUNT', operator: '==', value: 'LOG_RUNNING', negated: false },
+        { type: 'NpcKnowsInfoCondition', npc: 'DIA_NPC_GAROND', dialogRef: 'DIA_DragonHunt_Start' },
+      ],
+      actions: [],
+      calls: [],
+    },
+    DIA_DragonHunt_Investigate_Info: {
+      name: 'DIA_DragonHunt_Investigate_Info',
+      returnType: 'VOID',
+      conditions: [],
+      actions: [
+        { type: 'DialogLine', speaker: 'other', text: 'I tracked them to the old mine.', id: 'DIA_DragonHunt_Investigate_15_00' },
+        { type: 'SetVariableAction', variableName: 'MIS_DRAGONHUNT_STEP', operator: '=', value: 2 },
+        { type: 'LogEntry', topic: 'TOPIC_DRAGONHUNT', text: 'Follow the dragon trail into the mine.' },
+      ],
+      calls: [],
+    },
+    DIA_DragonHunt_Complete_Condition: {
+      name: 'DIA_DragonHunt_Complete_Condition',
+      returnType: 'INT',
+      conditions: [
+        { type: 'VariableCondition', variableName: 'MIS_DRAGONHUNT_STEP', operator: '>=', value: 2, negated: false },
+        { type: 'NpcIsDeadCondition', npc: 'DIA_NPC_DRAGON_LEADER', negated: false },
+      ],
+      actions: [],
+      calls: [],
+    },
+    DIA_DragonHunt_Complete_Info: {
+      name: 'DIA_DragonHunt_Complete_Info',
+      returnType: 'VOID',
+      conditions: [],
+      actions: [
+        { type: 'LogSetTopicStatus', topic: 'TOPIC_DRAGONHUNT', status: 'LOG_SUCCESS' },
+        { type: 'SetVariableAction', variableName: 'MIS_DRAGONHUNT', operator: '=', value: 'LOG_SUCCESS' },
+      ],
+      calls: [],
+    },
+    DIA_DragonHunt_Fail_Condition: {
+      name: 'DIA_DragonHunt_Fail_Condition',
+      returnType: 'INT',
+      conditions: [
+        { type: 'NpcGetDistToWpCondition', npc: 'hero', waypoint: 'OW_DRAGON_LAIR', operator: '>', value: 5000 },
+        { type: 'VariableCondition', variableName: 'MIS_DRAGONHUNT', operator: '==', value: 'LOG_RUNNING', negated: false },
+      ],
+      actions: [],
+      calls: [],
+    },
+    DIA_DragonHunt_Fail_Info: {
+      name: 'DIA_DragonHunt_Fail_Info',
+      returnType: 'VOID',
+      conditions: [],
+      actions: [
+        { type: 'LogSetTopicStatus', topic: 'TOPIC_DRAGONHUNT', status: 'LOG_FAILED' },
+        { type: 'SetVariableAction', variableName: 'MIS_DRAGONHUNT', operator: '=', value: 'LOG_FAILED' },
+      ],
+      calls: [],
+    },
+    DIA_GuildJoin_Start_Condition: {
+      name: 'DIA_GuildJoin_Start_Condition',
+      returnType: 'INT',
+      conditions: [
+        { type: 'VariableCondition', variableName: 'MIS_GUILDJOIN', operator: '==', value: 0, negated: false },
+        { type: 'NpcGetTalentSkillCondition', npc: 'hero', talent: 'NPC_TALENT_1H', operator: '>=', value: 30 },
+      ],
+      actions: [],
+      calls: [],
+    },
+    DIA_GuildJoin_Start_Info: {
+      name: 'DIA_GuildJoin_Start_Info',
+      returnType: 'VOID',
+      conditions: [],
+      actions: [
+        { type: 'CreateTopic', topic: 'TOPIC_GUILDJOIN', topicType: 'LOG_MISSION' },
+        { type: 'LogSetTopicStatus', topic: 'TOPIC_GUILDJOIN', status: 'LOG_RUNNING' },
+        { type: 'SetVariableAction', variableName: 'MIS_GUILDJOIN', operator: '=', value: 'LOG_RUNNING' },
+      ],
+      calls: [],
+    },
+    DIA_GuildJoin_Approve_Condition: {
+      name: 'DIA_GuildJoin_Approve_Condition',
+      returnType: 'INT',
+      conditions: [
+        { type: 'VariableCondition', variableName: 'MIS_GUILDJOIN', operator: '==', value: 'LOG_RUNNING', negated: false },
+        { type: 'VariableCondition', variableName: 'MIS_DRAGONHUNT', operator: '==', value: 'LOG_SUCCESS', negated: false },
+      ],
+      actions: [],
+      calls: [],
+    },
+    DIA_GuildJoin_Approve_Info: {
+      name: 'DIA_GuildJoin_Approve_Info',
+      returnType: 'VOID',
+      conditions: [],
+      actions: [
+        { type: 'LogSetTopicStatus', topic: 'TOPIC_GUILDJOIN', status: 'LOG_SUCCESS' },
+        { type: 'SetVariableAction', variableName: 'MIS_GUILDJOIN', operator: '=', value: 'LOG_SUCCESS' },
+      ],
+      calls: [],
+    },
+  },
+  constants: {
+    TOPIC_DRAGONHUNT: { name: 'TOPIC_DRAGONHUNT', type: 'string', value: '"Dragon Hunt"', filePath: 'mock/quests.d' },
+    TOPIC_GUILDJOIN: { name: 'TOPIC_GUILDJOIN', type: 'string', value: '"Join the Militia"', filePath: 'mock/quests.d' },
+  },
+  variables: {
+    MIS_DRAGONHUNT: { name: 'MIS_DRAGONHUNT', type: 'int', filePath: 'mock/quests.d' },
+    MIS_DRAGONHUNT_STEP: { name: 'MIS_DRAGONHUNT_STEP', type: 'int', filePath: 'mock/quests.d' },
+    MIS_GUILDJOIN: { name: 'MIS_GUILDJOIN', type: 'int', filePath: 'mock/quests.d' },
+  },
+  hasErrors: false,
+  errors: [],
+};
+
+export const nodeEditorMockQuests = ['TOPIC_DRAGONHUNT', 'TOPIC_GUILDJOIN'];

--- a/daedalus-dialog-editor/src/renderer/node-editor.html
+++ b/daedalus-dialog-editor/src/renderer/node-editor.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dandelion Node Editor Playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/node-editor.main.tsx"></script>
+  </body>
+</html>

--- a/daedalus-dialog-editor/src/renderer/node-editor.main.tsx
+++ b/daedalus-dialog-editor/src/renderer/node-editor.main.tsx
@@ -1,0 +1,44 @@
+import React, { useMemo, useState } from 'react';
+import ReactDOM from 'react-dom/client';
+import { ThemeProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import NodeEditorPlayground from './NodeEditorPlayground';
+import { themes, THEME_STORAGE_KEY, ThemeMode } from './theme';
+import { ThemeModeContext } from './themeContext';
+
+const getInitialTheme = (): ThemeMode => {
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark' || stored === 'gothic') {
+    return stored;
+  }
+  return 'dark';
+};
+
+const Root: React.FC = () => {
+  const [mode, setMode] = useState<ThemeMode>(getInitialTheme);
+
+  const handleSetMode = (nextMode: ThemeMode) => {
+    setMode(nextMode);
+    localStorage.setItem(THEME_STORAGE_KEY, nextMode);
+  };
+
+  const themeContextValue = useMemo(
+    () => ({ mode, setMode: handleSetMode }),
+    [mode],
+  );
+
+  return (
+    <ThemeModeContext.Provider value={themeContextValue}>
+      <ThemeProvider theme={themes[mode]}>
+        <CssBaseline />
+        <NodeEditorPlayground />
+      </ThemeProvider>
+    </ThemeModeContext.Provider>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Root />
+  </React.StrictMode>,
+);

--- a/daedalus-dialog-editor/tests/e2e/node-editor.spec.ts
+++ b/daedalus-dialog-editor/tests/e2e/node-editor.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Node editor playground', () => {
+  test('loads isolated quest flow with mock data', async ({ page }) => {
+    await page.goto('/node-editor.html');
+
+    await expect(page.getByText('Quest Node Editor Playground')).toBeVisible();
+    await expect(page.getByText('TOPIC_DRAGONHUNT')).toBeVisible();
+
+    await expect(page.locator('.react-flow__node')).toHaveCount(8);
+
+    await page.getByTestId('node-editor-quest-select').click();
+    await page.getByRole('option', { name: 'TOPIC_GUILDJOIN' }).click();
+
+    await expect(page.locator('.react-flow__node')).toHaveCount(5);
+  });
+});

--- a/daedalus-dialog-editor/vite.config.ts
+++ b/daedalus-dialog-editor/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 export default defineConfig({
   plugins: [react()],
@@ -9,6 +10,12 @@ export default defineConfig({
   build: {
     outDir: path.join(__dirname, 'dist/renderer'),
     emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        main: fileURLToPath(new URL('./src/renderer/index.html', import.meta.url)),
+        nodeEditor: fileURLToPath(new URL('./src/renderer/node-editor.html', import.meta.url)),
+      },
+    },
   },
   server: {
     port: 5173,


### PR DESCRIPTION
### Motivation

- Provide a fast, browser-only way to iterate the quest node editor without launching the full Electron app so Playwright UI tests and manual verification are faster. 
- Seed the playground with representative mock quest data (multiple quest steps, varied conditions and actions) to exercise graph rendering and switching.

### Description

- Add an isolated single-page entry at `src/renderer/node-editor.html` and a dedicated bootstrap `node-editor.main.tsx` that renders `NodeEditorPlayground`. 
- Implement `NodeEditorPlayground.tsx` which mounts `QuestFlow` with a quest selector and passes `writableEnabled={false}` for safe iteration. 
- Add rich mock semantic model in `src/renderer/mocks/nodeEditorMockData.ts` containing multiple dialogs, functions, conditions and actions. 
- Update `vite.config.ts` to include a multi-page build input for `node-editor.html` and add `dev:node-editor` script to `package.json` for quick local dev; add `tests/e2e/node-editor.spec.ts` as a focused Playwright spec.

### Testing

- Ran `npm run build:renderer --workspace daedalus-dialog-editor` which completed successfully. 
- Attempted `npm run test:e2e --workspace daedalus-dialog-editor -- tests/e2e/node-editor.spec.ts` which failed because Playwright browser binaries are not installed in this environment. 
- Launched the dev server (`vite`) and executed a headless Playwright script to capture a screenshot, which produced `artifacts/node-editor-playground.png` confirming the playground loads and renders nodes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a28bcab7848332a1d27a3ead95f833)