### PR TITLE
Add Playwright E2E test for multiple condition nodes/edges in node editor

### DIFF
--- a/daedalus-dialog-editor/tests/e2e/node-editor.spec.ts
+++ b/daedalus-dialog-editor/tests/e2e/node-editor.spec.ts
@@ -14,4 +14,19 @@ test.describe('Node editor playground', () => {
 
     await expect(page.locator('.react-flow__node')).toHaveCount(5);
   });
+
+  test('renders multiple condition nodes and condition edges for dialogs with multiple conditions', async ({ page }) => {
+    await page.goto('/node-editor.html');
+
+    const startDialogFunctionName = 'DIA_DragonHunt_Start_Info';
+    const relatedConditionNodes = page.locator(
+      `.react-flow__node[data-id^="condition-${startDialogFunctionName}-"]`
+    );
+    const relatedConditionEdges = page.locator(
+      `.react-flow__edge[data-id^="condition-edge-condition-${startDialogFunctionName}-"][data-id$="-${startDialogFunctionName}"]`
+    );
+
+    await expect(relatedConditionNodes).toHaveCount(2);
+    await expect(relatedConditionEdges).toHaveCount(2);
+  });
 });


### PR DESCRIPTION
### Motivation
- Verify that dialogs with multiple conditions produce multiple condition nodes and edges in the React Flow-based node editor so the graph wiring is correct.

### Description
- Add a Playwright E2E test in `daedalus-dialog-editor/tests/e2e/node-editor.spec.ts` that opens `/node-editor.html`, selects React Flow nodes and edges by `data-id` prefixes for `condition-...` and `condition-edge-...`, and asserts two condition nodes and two condition edges for `DIA_DragonHunt_Start_Info`.

### Testing
- Ran `npx playwright test tests/e2e/node-editor.spec.ts --project=chromium` which failed because the Playwright browser executable was not installed, and `npx playwright install chromium` failed due to the CDN download being blocked with HTTP 403 (domain forbidden).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a298904a7083329d0b01e5be96d962)