### PR TITLE
Simplify quest node editor to ComfyUI-only (drop React Flow)

### DIFF
--- a/daedalus-dialog-editor/tests/QuestFlow.ui.test.tsx
+++ b/daedalus-dialog-editor/tests/QuestFlow.ui.test.tsx
@@ -1,20 +1,18 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import QuestFlow from '../src/renderer/components/QuestFlow';
 import type { SemanticModel } from '../src/renderer/types/global';
 
-jest.mock('reactflow', () => {
-  const ReactModule = require('react');
-  return {
-    __esModule: true,
-    default: ({ children }: { children: React.ReactNode }) => <div data-testid="reactflow">{children}</div>,
-    Background: () => null,
-    Controls: () => null,
-    MiniMap: () => null,
-    useNodesState: () => [[], jest.fn(), jest.fn()],
-    useEdgesState: () => [[], jest.fn(), jest.fn()]
-  };
-});
+jest.mock('reactflow', () => ({
+  __esModule: true,
+  useNodesState: () => [[], jest.fn(), jest.fn()],
+  useEdgesState: () => [[], jest.fn(), jest.fn()]
+}));
+
+jest.mock('../src/renderer/components/QuestEditor/QuestLiteGraphCanvas', () => ({
+  __esModule: true,
+  default: () => <div data-testid="quest-litegraph-canvas" />
+}));
 
 jest.mock('../src/renderer/quest/domain/graph', () => ({
   buildQuestGraph: () => ({ nodes: [], edges: [] })
@@ -93,10 +91,10 @@ describe('QuestFlow UI', () => {
     );
 
     expect(screen.getByText('Writable quest editor is disabled (read-only fallback).')).toBeInTheDocument();
-    expect(screen.getByLabelText('Connect mode')).toBeDisabled();
+    expect(screen.getByText('Using ComfyUI-style node editor defaults.')).toBeInTheDocument();
   });
 
-  it('shows connect type selector when connect mode is enabled', () => {
+  it('renders only the comfy-style node editor canvas', () => {
     render(
       <QuestFlow
         semanticModel={createModel()}
@@ -105,7 +103,8 @@ describe('QuestFlow UI', () => {
       />
     );
 
-    fireEvent.click(screen.getByLabelText('Connect mode'));
-    expect(screen.getAllByText('Connect As').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('quest-litegraph-canvas')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Connect mode')).not.toBeInTheDocument();
+    expect(screen.queryByText('Connect As')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Motivation
- Consolidate to a single modern node editor implementation (ComfyUI / LiteGraph) and remove the legacy React Flow code path.
- Reduce UI complexity by removing many toolbar toggles and preserving sensible defaults for graph rendering and interaction.
- Eliminate dead code and feature permutations that were only required for the legacy editor.

### Description
- Removed React Flow rendering branch and related imports, always rendering the ComfyUI-style canvas via `QuestLiteGraphCanvas` in `daedalus-dialog-editor/src/renderer/components/QuestFlow.tsx`.
- Removed React Flow-specific node type mapping, connect-mode state (`connectMode`, `connectKind`), connect handlers (`onConnect`, `runTransitionConnectWithPreview`) and the condition inference helper; replaced mutable graph toggles with a memoized `graphOptions` default.
- Cleaned up UI toolbar to keep core actions/status text and a small caption indicating the ComfyUI-style defaults, removing checkbox toggles and selectors previously used to switch modes.
- Updated tests to reflect the simplified behavior by mocking `QuestLiteGraphCanvas` and `reactflow` hooks in `daedalus-dialog-editor/tests/QuestFlow.ui.test.tsx`.

### Testing
- Ran the targeted unit tests with `npm -C daedalus-dialog-editor test -- QuestFlow.ui.test.tsx`, and the updated test suite passed (2 tests, all green).
- Built the renderer bundle with `npm -C daedalus-dialog-editor run build:renderer`, which completed successfully.
- Launched the dev renderer and captured a UI screenshot of the node editor page via Playwright to validate the ComfyUI defaults visually (screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c7dd65cc8332b78581058acd8be5)