### PR TITLE
Add logical operator nodes and condition negation metadata to quest node editor

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/QuestEditor/Nodes/ConditionNode.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestEditor/Nodes/ConditionNode.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
-import { Box, Typography } from '@mui/material';
+import { Box, Chip, Typography } from '@mui/material';
 import { HelpOutline } from '@mui/icons-material';
 import BaseNode from './BaseNode';
 import ReferenceLink from '../../common/ReferenceLink';
@@ -15,6 +15,23 @@ const ConditionNode: React.FC<NodeProps> = ({ data, selected }) => {
       selected={selected}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+          {data.negated && (
+            <Chip
+              size="small"
+              label="NOT"
+              sx={{ height: 18, fontSize: 9, bgcolor: '#c62828', color: '#fff' }}
+            />
+          )}
+          {data.kind === 'logical' && data.operator && (
+            <Chip
+              size="small"
+              label={String(data.operator)}
+              sx={{ height: 18, fontSize: 9, bgcolor: '#6a1b9a', color: '#fff' }}
+            />
+          )}
+        </Box>
+
         <Box sx={{ bgcolor: '#1a1a1a', p: 1, borderRadius: 1 }}>
           <Typography variant="body2" component="div" sx={{ fontSize: 11, fontFamily: 'monospace', color: '#81d4fa' }}>
             <ExpressionText expression={data.expression || 'TRUE'} />

--- a/daedalus-dialog-editor/src/renderer/components/QuestEditor/Nodes/DialogNode.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestEditor/Nodes/DialogNode.tsx
@@ -56,14 +56,23 @@ const DialogNode: React.FC<NodeProps> = ({ data, selected }) => {
         {/* Handles */}
         <Box sx={{ position: 'relative', mt: 1, height: 20 }}>
           {/* Input: Condition */}
-          <Box sx={{ position: 'absolute', left: -20, top: 5, display: 'flex', alignItems: 'center' }}>
+          <Box sx={{ position: 'absolute', left: -20, top: -2, display: 'flex', alignItems: 'center' }}>
             <Handle
               type="target"
               position={Position.Left}
               id="in-condition"
               style={{ background: '#4caf50', width: 10, height: 10 }}
             />
-            <Typography variant="caption" sx={{ ml: 1, fontSize: 9, color: '#aaa' }}>Conditions</Typography>
+            <Typography variant="caption" sx={{ ml: 1, fontSize: 9, color: '#aaa' }}>Condition A</Typography>
+          </Box>
+          <Box sx={{ position: 'absolute', left: -20, top: 12, display: 'flex', alignItems: 'center' }}>
+            <Handle
+              type="target"
+              position={Position.Left}
+              id="in-condition-b"
+              style={{ background: '#81c784', width: 10, height: 10 }}
+            />
+            <Typography variant="caption" sx={{ ml: 1, fontSize: 9, color: '#aaa' }}>Condition B</Typography>
           </Box>
 
           {/* Output: Finished */}

--- a/daedalus-dialog-editor/src/renderer/types/questGraph.ts
+++ b/daedalus-dialog-editor/src/renderer/types/questGraph.ts
@@ -6,7 +6,8 @@ export type QuestGraphNodeKind =
   | 'misState'
   | 'logEntry'
   | 'dialog'
-  | 'condition';
+  | 'condition'
+  | 'logical';
 
 export type QuestGraphEdgeKind =
   | 'writes'
@@ -34,6 +35,8 @@ export interface QuestGraphNodeData {
   npc: string;
   description?: string;
   expression?: string;
+  operator?: 'AND' | 'OR';
+  negated?: boolean;
   type?: string;
   status?: string;
   variableName?: string;


### PR DESCRIPTION
### Motivation
- Dialog nodes previously accepted a single `conditions` input which forced multiple prerequisites to be composed externally.  
- Complex condition expressions and negation state were not represented in the node graph, making visualization and editing of composed logic awkward.  
- Provide explicit logical composition nodes so multiple conditions can be combined and negation preserved in the graph/UI.

### Description
- Add a new `logical` node kind and extend node payloads with `operator` and `negated` metadata in `QuestGraphNodeData`.  
- Update graph construction in `questGraphUtils.tsx` to detect multiple condition prerequisites, generate chained logical `AND` nodes, rewire edges through those logical nodes, and preserve per-condition `negated` flags.  
- Update the LiteGraph canvas (`QuestLiteGraphCanvas.tsx`) to add dual boolean input slots for logical nodes and two condition inputs for dialog nodes, and route edges to the correct input slots via `sourceHandle`/`targetHandle`.  
- Surface operator/negation UI in node renderers by adding chips to `ConditionNode.tsx` and adding a second condition handle to `DialogNode.tsx`, and add a regression test exercising composition and negation preservation in `questGraphUtils.test.tsx`.

### Testing
- Ran the targeted Jest suite with `pnpm test -- questGraphUtils.test.tsx` and all tests passed (`7 passed, 7 total`).  
- The changes were validated by the added/updated unit tests which verify logical node creation, edge rewiring, and preservation of `negated` metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d1fda8f48332989e9456145d247d)