### PR TITLE
Expose editable condition node fields and autocomplete in Quest Inspector

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/QuestEditor/commands/types.ts
+++ b/daedalus-dialog-editor/src/renderer/components/QuestEditor/commands/types.ts
@@ -44,6 +44,7 @@ export interface ConnectConditionCommand {
   variableName?: string;
   value?: string | number | boolean;
   operator?: '==' | '!=';
+  negated?: boolean;
 }
 
 export interface AddKnowsInfoRequirementCommand {
@@ -81,11 +82,13 @@ export interface RemoveConditionLinkCommand {
 export interface UpdateConditionLinkCommand {
   type: 'updateConditionLink';
   targetFunctionName: string;
+  conditionIndex?: number;
   oldVariableName: string;
   oldValue: string | number | boolean;
   variableName: string;
   value: string | number | boolean;
   operator?: '==' | '!=';
+  negated?: boolean;
 }
 
 export interface UpdateTransitionTextCommand {

--- a/daedalus-dialog-editor/src/renderer/components/QuestEditor/questGraphUtils.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestEditor/questGraphUtils.tsx
@@ -24,6 +24,8 @@ interface InternalNodeData {
   operator?: 'AND' | 'OR';
   negated?: boolean;
   kind: QuestGraphNodeKind;
+  condition?: DialogCondition;
+  conditionIndex?: number;
   sourceKind: QuestGraphSourceKind;
   entrySurface?: boolean;
   latentEntry?: boolean;
@@ -702,7 +704,9 @@ const buildQuestEdges = (
           latentEntry: false,
           entryReason: undefined,
           inferred: false,
-          touchesSelectedQuest: false
+          touchesSelectedQuest: false,
+          condition: cond,
+          conditionIndex: condIndex
         });
       }
 
@@ -838,7 +842,9 @@ const buildQuestEdges = (
           latentEntry: false,
           entryReason: undefined,
           inferred: false,
-          touchesSelectedQuest: false
+          touchesSelectedQuest: false,
+          condition: undefined,
+          conditionIndex: undefined
         });
       }
 
@@ -1194,6 +1200,8 @@ const calculateDagreLayout = (
         type: data.type,
         status: data.description,
         variableName: semanticModel.variables?.[misVarName] ? misVarName : undefined,
+        condition: data.condition,
+        conditionIndex: data.conditionIndex,
         kind: data.kind,
         sourceKind: data.sourceKind,
         entrySurface: data.entrySurface,

--- a/daedalus-dialog-editor/src/renderer/components/QuestFlow.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/QuestFlow.tsx
@@ -613,26 +613,30 @@ const QuestFlow: React.FC<QuestFlowProps> = ({ semanticModel, questName, writabl
       targetFunctionName: payload.targetFunctionName,
       variableName: payload.variableName,
       value: payload.value,
-      operator: payload.operator
+      operator: payload.operator,
     }, 'Failed to remove condition link.');
   }, [runQuestCommandWithPreview]);
 
   const handleUpdateConditionLink = useCallback(async (payload: {
     targetFunctionName: string;
+    conditionIndex?: number;
     oldVariableName: string;
     oldValue: string;
     variableName: string;
     value: string;
     operator: '==' | '!=';
+    negated?: boolean;
   }) => {
     await runQuestCommandWithPreview({
       type: 'updateConditionLink',
       targetFunctionName: payload.targetFunctionName,
+      conditionIndex: payload.conditionIndex,
       oldVariableName: payload.oldVariableName,
       oldValue: payload.oldValue,
       variableName: payload.variableName,
       value: payload.value,
-      operator: payload.operator
+      operator: payload.operator,
+      negated: payload.negated
     }, 'Failed to update condition link.');
   }, [runQuestCommandWithPreview]);
 
@@ -738,6 +742,7 @@ const QuestFlow: React.FC<QuestFlowProps> = ({ semanticModel, questName, writabl
 
       <QuestInspectorPanel
         questName={questName}
+        semanticModel={semanticModel}
         writableEnabled={writableEnabled}
         selectedNode={selectedNode}
         selectedEdge={selectedEdge}

--- a/daedalus-dialog-editor/src/renderer/types/questGraph.ts
+++ b/daedalus-dialog-editor/src/renderer/types/questGraph.ts
@@ -1,4 +1,5 @@
 import type { Edge, Node } from 'reactflow';
+import type { DialogCondition } from './global';
 
 export type QuestGraphNodeKind =
   | 'topic'
@@ -40,6 +41,8 @@ export interface QuestGraphNodeData {
   type?: string;
   status?: string;
   variableName?: string;
+  condition?: DialogCondition;
+  conditionIndex?: number;
   kind: QuestGraphNodeKind;
   sourceKind?: QuestGraphSourceKind;
   entrySurface?: boolean;

--- a/daedalus-dialog-editor/tests/QuestInspectorPanel.test.tsx
+++ b/daedalus-dialog-editor/tests/QuestInspectorPanel.test.tsx
@@ -16,6 +16,30 @@ const createRequiresEdge = (expression: string): QuestGraphEdge => ({
   }
 });
 
+
+const createConditionNode = () => ({
+  id: 'condition-node-1',
+  position: { x: 0, y: 0 },
+  data: {
+    kind: 'condition' as const,
+    label: 'Variable Condition',
+    npc: 'External/World',
+    expression: 'MIS_TEST == LOG_RUNNING',
+    conditionIndex: 0,
+    condition: {
+      type: 'VariableCondition' as const,
+      variableName: 'MIS_TEST',
+      value: 'LOG_RUNNING',
+      operator: '==',
+      negated: false
+    },
+    provenance: {
+      functionName: 'DIA_Target_Info'
+    }
+  },
+  type: 'condition' as const
+});
+
 const baseProps = {
   questName: 'TOPIC_TEST',
   writableEnabled: true,
@@ -96,6 +120,42 @@ describe('QuestInspectorPanel requires edge editing', () => {
     });
   });
 
+
+  it('edits variable condition node fields with autocomplete-backed variable input', () => {
+    render(
+      <QuestInspectorPanel
+        {...baseProps}
+        selectedNode={createConditionNode()}
+        selectedEdge={null}
+        semanticModel={{
+          dialogs: {},
+          functions: {},
+          constants: {},
+          variables: {
+            MIS_TEST: { name: 'MIS_TEST', type: 'int' }
+          },
+          instances: {},
+          hasErrors: false,
+          errors: []
+        }}
+      />
+    );
+
+    expect(screen.getByLabelText('Variable Name')).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Value'), { target: { value: 'LOG_SUCCESS' } });
+    fireEvent.click(screen.getAllByText('Preview Diff')[0]);
+
+    expect(baseProps.onUpdateConditionLink).toHaveBeenCalledWith({
+      targetFunctionName: 'DIA_Target_Info',
+      conditionIndex: 0,
+      oldVariableName: 'MIS_TEST',
+      oldValue: 'LOG_RUNNING',
+      variableName: 'MIS_TEST',
+      value: 'LOG_SUCCESS',
+      operator: '==',
+      negated: false
+    });
+  });
   it('shows read-only message for range requires expressions', () => {
     render(
       <QuestInspectorPanel


### PR DESCRIPTION
### Motivation
- Condition nodes in the quest graph should reflect the same fields as dialog condition objects so users can inspect and edit them directly from the quest inspector. 
- Editing should be precise (target the exact parsed condition in a function) and should reuse existing autocomplete UX from the dialog editor.

### Description
- Added `condition` and `conditionIndex` to `QuestGraphNodeData` so rendered nodes carry the underlying parsed `DialogCondition` and its index (`conditionIndex`) (`src/renderer/types/questGraph.ts`).
- Populated `condition`/`conditionIndex` when building graph nodes and unresolved condition nodes in `buildQuestGraph`/`questGraphUtils` so inspector can target the specific condition entry (`src/renderer/components/QuestEditor/questGraphUtils.tsx`).
- Extended `QuestInspectorPanel` to accept `semanticModel`, to expose an editable UI for `VariableCondition` nodes (variable name with `VariableAutocomplete`, operator, value, negated) and to safely handle missing `entrySurfaceNodes` (`src/renderer/components/QuestEditor/Inspector/QuestInspectorPanel.tsx`).
- Extended command types and execution for updating condition links to support index-aware updates and `negated` preservation; updated `executeUpdateConditionLinkCommand` to accept `conditionIndex` and `negated` and to perform index-based matching/duplicate checks (`src/renderer/components/QuestEditor/commands/types.ts`, `src/renderer/components/QuestEditor/commands/updateConditionLink.ts`).
- Wired the inspector into `QuestFlow`: passed `semanticModel` for autocomplete data and forwarded the richer `updateConditionLink` payload (including `conditionIndex`/`negated`) through the quest command preview flow (`src/renderer/components/QuestFlow.tsx`).
- Added/updated unit test coverage for inspector condition editing and the new editable flow (`tests/QuestInspectorPanel.test.tsx`).

### Testing
- Ran focused unit tests with `npm test -- QuestInspectorPanel.test.tsx questCommands.setMisState.test.ts` and all tests passed locally (both suites passed).
- Built the renderer with `npm run build:renderer` successfully to ensure the renderer bundle compiles.
- Attempted to capture a UI screenshot with Playwright while running `vite`, but the container Chromium crashed with a `SIGSEGV` during launch so no screenshot was produced (this does not affect the code changes or tests which passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d530f528833288e9fd44b4a79058)