### PR TITLE
D1: share history snapshot models structurally instead of deep-cloning

### DIFF
--- a/daedalus-dialog-editor/src/renderer/store/historyStore.ts
+++ b/daedalus-dialog-editor/src/renderer/store/historyStore.ts
@@ -3,7 +3,6 @@ import { immer } from 'zustand/middleware/immer';
 import { enableMapSet } from 'immer';
 import { useFileStore } from './fileStore';
 import {
-  cloneSemanticModel,
   cloneQuestNodePositionsForFile,
   normalizeBatchFilePaths,
 } from '../utils/historyUtils';
@@ -73,12 +72,19 @@ interface HistoryStore {
 // Helpers operating on the Immer-draft history maps + fileStore
 // ---------------------------------------------------------------------------
 
+/**
+ * Snapshot models are stored by reference, never deep-cloned: fileStore state
+ * is produced by Immer (copy-on-write, auto-frozen), so a captured model can
+ * never be mutated in place afterwards — later edits replace it with a new
+ * structurally shared object. The model passed here must therefore come from
+ * plain fileStore state (`useFileStore.getState()`), not from an Immer draft.
+ */
 const createEditSnapshot = (
   model: SemanticModel,
   nodePositions: Map<string, QuestNodePositionMap> | undefined,
   timestamp: number
 ): EditSnapshot => ({
-  model: cloneSemanticModel(model),
+  model,
   nodePositions: cloneQuestNodePositionsForFile(nodePositions),
   timestamp,
 });
@@ -103,70 +109,88 @@ const pushUncoalescedSnapshot = (
 };
 
 /**
- * Apply a single undo step for filePath on the unified stack: restores the
- * previous model AND node positions. Mutates the Immer draft maps and calls
- * fileStore._applyHistoryModelUpdate for the file state update.
- * Returns true if an undo step was applied.
+ * One planned undo/redo step. Built from plain (non-draft) store state so the
+ * snapshot model can be handed to fileStore by reference — reading it through
+ * an Immer draft inside set() would leak a revocable proxy.
  */
-const applyUndoForFile = (
+interface RestoreStep {
+  filePath: string;
+  snapshot: EditSnapshot;
+  currentModel: SemanticModel;
+}
+
+/** Plan an undo step for filePath, or null if there is nothing to undo. */
+const planUndoForFile = (
   editHistory: Map<string, EditHistoryState>,
-  questNodePositions: Map<string, Map<string, QuestNodePositionMap>>,
   filePath: string
-): boolean => {
+): RestoreStep | null => {
   const fileState = useFileStore.getState().openFiles.get(filePath);
   const history = editHistory.get(filePath);
   if (!fileState || !history || history.past.length === 0) {
-    return false;
+    return null;
   }
-
-  const previousSnapshot = history.past[history.past.length - 1];
-  history.future = [
-    createEditSnapshot(fileState.semanticModel, questNodePositions.get(filePath), 0),
-    ...history.future
-  ];
-  history.past = history.past.slice(0, history.past.length - 1);
-  questNodePositions.set(filePath, cloneQuestNodePositionsForFile(previousSnapshot.nodePositions));
-
-  // Update file store separately (outside the Immer draft)
-  useFileStore.getState()._applyHistoryModelUpdate(
+  return {
     filePath,
-    cloneSemanticModel(previousSnapshot.model)
-  );
-
-  return true;
+    snapshot: history.past[history.past.length - 1],
+    currentModel: fileState.semanticModel,
+  };
 };
 
-/**
- * Apply a single redo step for filePath on the unified stack.
- * Returns true if a redo step was applied.
- */
-const applyRedoForFile = (
+/** Plan a redo step for filePath, or null if there is nothing to redo. */
+const planRedoForFile = (
   editHistory: Map<string, EditHistoryState>,
-  questNodePositions: Map<string, Map<string, QuestNodePositionMap>>,
   filePath: string
-): boolean => {
+): RestoreStep | null => {
   const fileState = useFileStore.getState().openFiles.get(filePath);
   const history = editHistory.get(filePath);
   if (!fileState || !history || history.future.length === 0) {
-    return false;
+    return null;
   }
+  return {
+    filePath,
+    snapshot: history.future[0],
+    currentModel: fileState.semanticModel,
+  };
+};
 
-  const nextSnapshot = history.future[0];
+/** Move the stacks for a planned undo step. Mutates the Immer draft maps. */
+const commitUndoForFile = (
+  editHistory: Map<string, EditHistoryState>,
+  questNodePositions: Map<string, Map<string, QuestNodePositionMap>>,
+  step: RestoreStep
+): void => {
+  const history = editHistory.get(step.filePath);
+  if (!history) return;
+  history.future = [
+    createEditSnapshot(step.currentModel, questNodePositions.get(step.filePath), 0),
+    ...history.future
+  ];
+  history.past = history.past.slice(0, history.past.length - 1);
+  questNodePositions.set(step.filePath, cloneQuestNodePositionsForFile(step.snapshot.nodePositions));
+};
+
+/** Move the stacks for a planned redo step. Mutates the Immer draft maps. */
+const commitRedoForFile = (
+  editHistory: Map<string, EditHistoryState>,
+  questNodePositions: Map<string, Map<string, QuestNodePositionMap>>,
+  step: RestoreStep
+): void => {
+  const history = editHistory.get(step.filePath);
+  if (!history) return;
   history.past = [
     ...history.past,
-    createEditSnapshot(fileState.semanticModel, questNodePositions.get(filePath), 0)
+    createEditSnapshot(step.currentModel, questNodePositions.get(step.filePath), 0)
   ];
   if (history.past.length > MAX_HISTORY_SIZE) history.past.shift();
   history.future = history.future.slice(1);
-  questNodePositions.set(filePath, cloneQuestNodePositionsForFile(nextSnapshot.nodePositions));
+  questNodePositions.set(step.filePath, cloneQuestNodePositionsForFile(step.snapshot.nodePositions));
+};
 
-  // Update file store separately (outside the Immer draft)
-  useFileStore.getState()._applyHistoryModelUpdate(
-    filePath,
-    cloneSemanticModel(nextSnapshot.model)
-  );
-
-  return true;
+/** Restore the planned snapshot models into fileStore (outside the Immer draft). */
+const applyRestoreSteps = (steps: RestoreStep[]): void => {
+  steps.forEach((step) => {
+    useFileStore.getState()._applyHistoryModelUpdate(step.filePath, step.snapshot.model);
+  });
 };
 
 export const useHistoryStore = create<HistoryStore>()(immer((set, get) => ({
@@ -207,15 +231,21 @@ export const useHistoryStore = create<HistoryStore>()(immer((set, get) => ({
   },
 
   undo: (filePath: string) => {
+    const step = planUndoForFile(get().editHistory, filePath);
+    if (!step) return;
     set((state) => {
-      applyUndoForFile(state.editHistory, state.questNodePositions, filePath);
+      commitUndoForFile(state.editHistory, state.questNodePositions, step);
     });
+    applyRestoreSteps([step]);
   },
 
   redo: (filePath: string) => {
+    const step = planRedoForFile(get().editHistory, filePath);
+    if (!step) return;
     set((state) => {
-      applyRedoForFile(state.editHistory, state.questNodePositions, filePath);
+      commitRedoForFile(state.editHistory, state.questNodePositions, step);
     });
+    applyRestoreSteps([step]);
   },
 
   canUndo: (filePath: string) => {
@@ -283,55 +313,45 @@ export const useHistoryStore = create<HistoryStore>()(immer((set, get) => ({
   canRedoQuestModel: (filePath: string) => get().canRedo(filePath),
 
   undoLastQuestBatch: () => {
+    const { editHistory, questBatchHistory } = get();
+    const latestBatch = questBatchHistory.past[questBatchHistory.past.length - 1];
+    if (!latestBatch || latestBatch.length === 0) {
+      return;
+    }
+
+    const steps = normalizeBatchFilePaths(latestBatch)
+      .map((filePath) => planUndoForFile(editHistory, filePath))
+      .filter((step): step is RestoreStep => step !== null);
+
     set((state) => {
-      const latestBatch = state.questBatchHistory.past[state.questBatchHistory.past.length - 1];
-      if (!latestBatch || latestBatch.length === 0) {
-        return;
-      }
-
-      const normalizedBatch = normalizeBatchFilePaths(latestBatch);
-      const actuallyUndone: string[] = [];
-      normalizedBatch.forEach((filePath) => {
-        const didUndo = applyUndoForFile(state.editHistory, state.questNodePositions, filePath);
-        if (didUndo) {
-          actuallyUndone.push(filePath);
-        }
-      });
-
-      if (actuallyUndone.length === 0) {
-        state.questBatchHistory.past = state.questBatchHistory.past.slice(0, state.questBatchHistory.past.length - 1);
-        return;
-      }
-
+      steps.forEach((step) => commitUndoForFile(state.editHistory, state.questNodePositions, step));
       state.questBatchHistory.past = state.questBatchHistory.past.slice(0, state.questBatchHistory.past.length - 1);
-      state.questBatchHistory.future = [actuallyUndone, ...state.questBatchHistory.future];
+      if (steps.length > 0) {
+        state.questBatchHistory.future = [steps.map((step) => step.filePath), ...state.questBatchHistory.future];
+      }
     });
+    applyRestoreSteps(steps);
   },
 
   redoLastQuestBatch: () => {
+    const { editHistory, questBatchHistory } = get();
+    const latestBatch = questBatchHistory.future[0];
+    if (!latestBatch || latestBatch.length === 0) {
+      return;
+    }
+
+    const steps = normalizeBatchFilePaths(latestBatch)
+      .map((filePath) => planRedoForFile(editHistory, filePath))
+      .filter((step): step is RestoreStep => step !== null);
+
     set((state) => {
-      const latestBatch = state.questBatchHistory.future[0];
-      if (!latestBatch || latestBatch.length === 0) {
-        return;
-      }
-
-      const normalizedBatch = normalizeBatchFilePaths(latestBatch);
-      const actuallyRedone: string[] = [];
-      normalizedBatch.forEach((filePath) => {
-        const didRedo = applyRedoForFile(state.editHistory, state.questNodePositions, filePath);
-        if (didRedo) {
-          actuallyRedone.push(filePath);
-        }
-      });
-
-      if (actuallyRedone.length === 0) {
-        state.questBatchHistory.future = state.questBatchHistory.future.slice(1);
-        return;
-      }
-
+      steps.forEach((step) => commitRedoForFile(state.editHistory, state.questNodePositions, step));
       state.questBatchHistory.future = state.questBatchHistory.future.slice(1);
-      state.questBatchHistory.past = [...state.questBatchHistory.past, actuallyRedone];
+      if (steps.length > 0) {
+        state.questBatchHistory.past = [...state.questBatchHistory.past, steps.map((step) => step.filePath)];
+      }
     });
+    applyRestoreSteps(steps);
   },
 
   canUndoLastQuestBatch: () => get().questBatchHistory.past.length > 0,

--- a/daedalus-dialog-editor/src/renderer/utils/historyUtils.ts
+++ b/daedalus-dialog-editor/src/renderer/utils/historyUtils.ts
@@ -16,6 +16,8 @@ export type QuestNodePositionMap = Map<string, QuestNodePosition>;
  * Snapshot used by the unified edit history (dialog + quest surfaces).
  * The timestamp coalesces rapid edits into a single undo step; quest-surface
  * snapshots use timestamp 0 so later edits never coalesce into them.
+ * The model is held by reference (structurally shared with Immer-frozen
+ * fileStore state), not deep-cloned.
  */
 export interface EditSnapshot {
   model: SemanticModel;
@@ -50,14 +52,4 @@ export function cloneQuestNodePositionsForFile(
     cloned.set(questName, nextNodeMap);
   });
   return cloned;
-}
-
-export function cloneSemanticModel(model: SemanticModel): SemanticModel {
-  try {
-    if (typeof structuredClone === 'function') return structuredClone(model);
-  } catch {
-    // structuredClone fails on Immer proxy objects (e.g. when called inside a
-    // historyStore.set() callback); fall through to the JSON-based clone.
-  }
-  return JSON.parse(JSON.stringify(model)) as SemanticModel;
 }

--- a/daedalus-dialog-editor/tests/historyStore.editHistory.test.ts
+++ b/daedalus-dialog-editor/tests/historyStore.editHistory.test.ts
@@ -1,6 +1,6 @@
 import { useFileStore } from '../src/renderer/store/fileStore';
 import { useHistoryStore } from '../src/renderer/store/historyStore';
-import type { SemanticModel } from '../src/renderer/types/global';
+import type { Dialog, SemanticModel } from '../src/renderer/types/global';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -262,6 +262,50 @@ describe('historyStore – undo and redo', () => {
 
   it('does nothing on undo for a file that is not open', () => {
     expect(() => useHistoryStore.getState().undo('nonexistent.d')).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural sharing: snapshots reference Immer-frozen models, no deep clones
+// ---------------------------------------------------------------------------
+
+describe('historyStore – snapshot structural sharing', () => {
+  beforeEach(resetStores);
+
+  it('pushSnapshot stores the current model by reference instead of deep-cloning', () => {
+    const liveModel = useFileStore.getState().getFileState(filePath)!.semanticModel;
+
+    useHistoryStore.getState().pushSnapshot(filePath);
+
+    const snapshot = useHistoryStore.getState().editHistory.get(filePath)!.past[0];
+    expect(snapshot.model).toBe(liveModel);
+  });
+
+  it('undo restores the snapshot model by reference instead of a clone', () => {
+    const initialModel = useFileStore.getState().getFileState(filePath)!.semanticModel;
+    useHistoryStore.getState().pushSnapshot(filePath);
+    useFileStore.getState()._applyHistoryModelUpdate(filePath, makeModel('modified'));
+
+    useHistoryStore.getState().undo(filePath);
+
+    expect(useFileStore.getState().getFileState(filePath)!.semanticModel).toBe(initialModel);
+  });
+
+  it('a fileStore edit after pushSnapshot does not leak into the shared snapshot', () => {
+    useHistoryStore.getState().pushSnapshot(filePath);
+
+    // updateDialog goes through fileStore's Immer produce: copy-on-write must
+    // leave the snapshot's model untouched although it is shared by reference
+    useFileStore.getState().updateDialog(filePath, 'DIA_Test', {
+      properties: { npc: 'edited', information: 'DIA_Test_Info' }
+    } as Dialog);
+    expect(currentNpc()).toBe('edited');
+
+    const snapshot = useHistoryStore.getState().editHistory.get(filePath)!.past[0];
+    expect(snapshot.model.dialogs?.DIA_Test?.properties?.npc).toBe('initial');
+
+    useHistoryStore.getState().undo(filePath);
+    expect(currentNpc()).toBe('initial');
   });
 });
 

--- a/docs/plans/frontend-editor-review-fixes.md
+++ b/docs/plans/frontend-editor-review-fixes.md
@@ -26,6 +26,7 @@ Each item is fixed TDD-style: failing test → minimal fix → green. Status val
 | F5 | `deleteVariable` merges the old merged model additively, so deleted constants/variables stay visible in `mergedSemanticModel` (VariableManager) until an unrelated re-merge. | `store/projectStore.ts`, `components/VariableManager.tsx` | done |
 | F6 | Every model edit rebuilt the whole dialog index (O(project) per keystroke) via `storeSync` → `updateFileModel`, even for action edits that do not change the dialog set. The index rebuild is now skipped unless the file's (dialogName, npc) set changed; the merged-model re-merge stays synchronous (it feeds live edits) and already skips unrelated files. | `store/projectStore.ts` | done |
 | F7 | Zustand object-literal selectors without shallow equality re-render on every store change (`QuestFlow`, `QuestEditor`, `IngestedFilesDialog`); `App`/`ThreeColumnLayout` subscribe to whole stores. | renderer components | done |
+| D1 | History snapshots deep-cloned the entire semantic model (up to 50× per file, on push and on restore). Snapshots now hold the model by reference — safe because fileStore state is Immer-produced (copy-on-write, auto-frozen). Undo/redo restructured into plan (plain state) / commit (draft) / apply phases so no Immer draft proxy reaches fileStore. | `store/historyStore.ts`, `utils/historyUtils.ts` | done |
 
 ## Architecture drift & dead code
 
@@ -48,6 +49,5 @@ Each item is fixed TDD-style: failing test → minimal fix → green. Status val
 
 | ID | Finding | Reason |
 |----|---------|--------|
-| D1 | History snapshots deep-clone the entire semantic model (up to 50× per file). Structural sharing is possible (immer freezes state) but aliasing risks need a dedicated change with its own test pass. | Needs focused follow-up |
 | D2 | Physically move pure quest logic from `components/QuestEditor/*` into `quest/domain/` and remove the reactflow type dependency. | Large import-churn refactor; tracked in `docs/refactoring-targets.md` |
 | D3 | `properties.information`/`condition` string-vs-object union should be encoded once in the model types instead of `as any` casts at call sites. | Type-model change touching parser + editor |


### PR DESCRIPTION
History snapshots deep-cloned the entire semantic model on every push and
again on every undo/redo restore (up to 50x per file). Snapshots now hold
the model by reference, which is safe because fileStore state is produced
by Immer (copy-on-write, auto-frozen): later edits replace the model with
a new structurally shared object and can never mutate a captured one.

Undo/redo is restructured into three phases so the restored model never
passes through an Immer draft proxy: plan (read snapshot from plain state),
commit (move stacks inside set), apply (hand the plain model reference to
fileStore). The now-unused cloneSemanticModel helper is removed.

https://claude.ai/code/session_012UoD3aruNcsdpKpM1jCavL