### PR TITLE
Fix invalid identifiers in generated code (B_Attack defaults, TOPIC_ vs MIS_)

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/actionTemplates.ts
+++ b/daedalus-dialog-editor/src/renderer/components/actionTemplates.ts
@@ -78,7 +78,7 @@ export const ACTION_TEMPLATES = {
     quantity
   }),
 
-  attackAction: (attacker: string = 'self', target: string = 'hero', attackReason: string = 'ATTACK_REASON_KILL', damage: number = 0): AttackAction => ({
+  attackAction: (attacker: string = 'self', target: string = 'other', attackReason: string = 'AR_NONE', damage: number = 1): AttackAction => ({
     type: 'AttackAction',
     attacker,
     target,

--- a/daedalus-dialog-editor/tests/actionTemplates.test.ts
+++ b/daedalus-dialog-editor/tests/actionTemplates.test.ts
@@ -1,0 +1,15 @@
+import { ACTION_TEMPLATES } from '../src/renderer/components/actionTemplates';
+
+describe('ACTION_TEMPLATES.attackAction', () => {
+  // Issue #116: generated `B_Attack (self, hero, ATTACK_REASON_KILL, 1);` fails
+  // in-game with "Unknown Identifier". Gothic 2 scripts use
+  // `B_Attack (self, other, AR_NONE, 1);` (see daedalus-parser/reference/DIA_Farim.d).
+  test('defaults match valid Gothic 2 identifiers', () => {
+    const action = ACTION_TEMPLATES.attackAction();
+
+    expect(action.attacker).toBe('self');
+    expect(action.target).toBe('other');
+    expect(action.attackReason).toBe('AR_NONE');
+    expect(action.damage).toBe(1);
+  });
+});

--- a/daedalus-parser/src/semantic/conditionTypes.ts
+++ b/daedalus-parser/src/semantic/conditionTypes.ts
@@ -297,7 +297,9 @@ export class QuestStateCondition implements CodeGeneratable {
   }
 
   generateCode(_options: CodeGenOptions): string {
-    return `${this.questVariable} == ${this.state}`;
+    // TOPIC_ constants are strings; the state check must use the MIS_ int variable.
+    const misVariable = this.questVariable.replace(/^topic_/i, 'MIS_');
+    return `${misVariable} == ${this.state}`;
   }
 
   toDisplayString(): string {

--- a/daedalus-parser/test/condition-parsing.test.js
+++ b/daedalus-parser/test/condition-parsing.test.js
@@ -649,6 +649,20 @@ test('QuestStateCondition generates code with LOG_SUCCESS', () => {
   assert.strictEqual(code, 'MIS_TestQuest == LOG_SUCCESS');
 });
 
+// Issue #174: a TOPIC_ constant is a string and cannot be compared to a log
+// state; the quest state check must use the corresponding MIS_ int variable.
+test('QuestStateCondition normalizes TOPIC_ prefix to MIS_', () => {
+  const condition = new QuestStateCondition('TOPIC_GefaehrlicheJagt', 'LOG_RUNNING');
+  const code = condition.generateCode({});
+  assert.strictEqual(code, 'MIS_GefaehrlicheJagt == LOG_RUNNING');
+});
+
+test('QuestStateCondition normalizes Topic_ prefix case-insensitively', () => {
+  const condition = new QuestStateCondition('Topic_TestQuest', 'LOG_SUCCESS');
+  const code = condition.generateCode({});
+  assert.strictEqual(code, 'MIS_TestQuest == LOG_SUCCESS');
+});
+
 test('Should parse OR conditions and set conditionOperator to OR', () => {
   const source = `
 instance DIA_Test_OR(C_INFO)


### PR DESCRIPTION
Two code-generation correctness fixes:

- **#116**: the Attack action template defaulted to `B_Attack (self, hero, ATTACK_REASON_KILL, 0)`. Both `hero` and `ATTACK_REASON_KILL` are unknown identifiers in Gothic 2. New defaults match the reference corpus: `B_Attack (self, other, AR_NONE, 1);`
- **#174**: `QuestStateCondition` emitted `TOPIC_X == LOG_RUNNING` when the editor stored a topic name. TOPIC_ constants are strings; the check must use the MIS_ int variable. The code generator now normalizes a leading `TOPIC_` to `MIS_`.

Both fixes are covered by new tests (Jest template test, parser unit tests).

Fixes #116
Fixes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)