### PR TITLE
Fix If/Else block text loss and add condition templates

### DIFF
--- a/daedalus-dialog-editor/src/renderer/components/ActionCard.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/ActionCard.tsx
@@ -70,16 +70,20 @@ const ActionCard = React.memo(React.forwardRef<HTMLInputElement, ActionCardProps
   const handleUpdate = useCallback((updated: typeof localAction) => {
     // Update local state immediately for responsive UI
     setLocalAction(updated);
+    localActionRef.current = updated;
 
     // Debounce parent updates - only sync after user stops typing
     if (updateTimerRef.current) {
       clearTimeout(updateTimerRef.current);
     }
     updateTimerRef.current = setTimeout(() => {
-      updateActionAtPath(path, updated);
+      // Resolve path/action via refs at fire time: the card's path may have
+      // shifted while the debounce was pending (insertion above, undo, drag),
+      // and a lexically captured path would write the text onto a sibling.
+      updateActionRef.current(pathRef.current, localActionRef.current);
       updateTimerRef.current = null;
     }, 300); // 300ms debounce
-  }, [updateActionAtPath, path]);
+  }, []);
 
   // Cleanup timer on unmount - use refs to avoid stale closures
   React.useEffect(() => {

--- a/daedalus-dialog-editor/src/renderer/components/actionRenderers/ConditionalActionRenderer.tsx
+++ b/daedalus-dialog-editor/src/renderer/components/actionRenderers/ConditionalActionRenderer.tsx
@@ -4,19 +4,34 @@ import {
   Button,
   Divider,
   IconButton,
+  Menu,
+  MenuItem,
   Paper,
   Stack,
   TextField,
   Tooltip,
   Typography
 } from '@mui/material';
-import { Add as AddIcon, Delete as DeleteIcon } from '@mui/icons-material';
+import { Add as AddIcon, Delete as DeleteIcon, PlaylistAdd as PlaylistAddIcon } from '@mui/icons-material';
 import type { BaseActionRendererProps } from './types';
 import type { ConditionalAction } from '../../types/global';
 import type { ActionTypeId } from '../actionTypes';
 import type { ActionBranchKey } from '../nestedActionUtils';
 import ActionsList from '../ActionsList';
 import ActionTypeMenu from '../common/ActionTypeMenu';
+
+/**
+ * Daedalus snippets for common If-block conditions (issue #145: parity with
+ * the dialog-level condition editor, especially "knows info").
+ */
+const CONDITION_TEMPLATES: ReadonlyArray<{ label: string; snippet: string }> = [
+  { label: 'NPC Knows Dialog', snippet: 'Npc_KnowsInfo(other, DIA_)' },
+  { label: 'Variable Check', snippet: 'MyVariable == 1' },
+  { label: 'NPC Has Items', snippet: 'Npc_HasItems(other, ItMi_Gold) >= 1' },
+  { label: 'NPC Is In State', snippet: 'Npc_IsInState(self, ZS_Talk)' },
+  { label: 'NPC Is Dead', snippet: 'Npc_IsDead(self)' },
+  { label: 'Quest State', snippet: 'MIS_ == LOG_RUNNING' }
+];
 
 const ConditionalActionRenderer: React.FC<BaseActionRendererProps> = ({
   action,
@@ -45,7 +60,15 @@ const ConditionalActionRenderer: React.FC<BaseActionRendererProps> = ({
 }) => {
   const typedAction = action as ConditionalAction;
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [templateMenuAnchor, setTemplateMenuAnchor] = useState<HTMLElement | null>(null);
   const [activeBranch, setActiveBranch] = useState<ActionBranchKey>('then');
+
+  const insertConditionTemplate = (snippet: string) => {
+    const existing = (typedAction.condition || '').trim();
+    const condition = existing ? `${existing} && ${snippet}` : snippet;
+    handleUpdate({ ...typedAction, condition });
+    setTemplateMenuAnchor(null);
+  };
 
   const branchSections = useMemo(() => ([
     { branch: 'then' as const, label: 'If' },
@@ -71,12 +94,33 @@ const ConditionalActionRenderer: React.FC<BaseActionRendererProps> = ({
             size="small"
             inputRef={mainFieldRef}
           />
+          <Tooltip title="Insert condition template">
+            <IconButton
+              size="small"
+              onClick={(event) => setTemplateMenuAnchor(event.currentTarget)}
+              aria-label="Insert condition template"
+            >
+              <PlaylistAddIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
           <Tooltip title="Delete block">
             <IconButton size="small" color="error" onClick={handleDelete} aria-label="Delete conditional block">
               <DeleteIcon fontSize="small" />
             </IconButton>
           </Tooltip>
         </Box>
+
+        <Menu
+          anchorEl={templateMenuAnchor}
+          open={Boolean(templateMenuAnchor)}
+          onClose={() => setTemplateMenuAnchor(null)}
+        >
+          {CONDITION_TEMPLATES.map(({ label, snippet }) => (
+            <MenuItem key={label} onClick={() => insertConditionTemplate(snippet)}>
+              {label}
+            </MenuItem>
+          ))}
+        </Menu>
 
         {branchSections.map(({ branch, label }) => {
           const branchActions = branch === 'then' ? typedAction.thenActions : typedAction.elseActions;

--- a/daedalus-dialog-editor/tests/ActionCard.debounceStalePath.test.tsx
+++ b/daedalus-dialog-editor/tests/ActionCard.debounceStalePath.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Regression test for issue #145: the debounced text-sync timer in ActionCard
+ * captured `path` lexically. When the card's path shifts while the 300ms
+ * debounce is pending (an action inserted above it, e.g. CreateTopic's
+ * auto-append, undo, or drag reorder), the late timer wrote the typed text to
+ * the OLD path — overwriting a different action ("randomly deletes text").
+ * The timer must resolve the path via ref at fire time, like the unmount
+ * cleanup already does.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import ActionCard from '../src/renderer/components/ActionCard';
+import type { DialogAction } from '../src/renderer/types/global';
+import type { ActionPath } from '../src/renderer/components/nestedActionUtils';
+
+describe('ActionCard debounced update path staleness', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function renderCard(path: ActionPath, action: DialogAction, updateActionAtPath: jest.Mock) {
+    const noop = jest.fn();
+    const props = {
+      action,
+      path,
+      index: path[path.length - 1] as number,
+      totalActions: 5,
+      npcName: 'Arog',
+      updateActionAtPath,
+      deleteActionAtPath: noop,
+      focusActionAtPath: noop,
+      addDialogLineAfterPath: noop,
+      deleteActionAndFocusPrevAtPath: noop,
+      addActionAfterPath: noop,
+      addActionToBranchEnd: noop,
+      moveAction: noop,
+      registerActionRef: jest.fn(),
+      getVisibleActionPaths: () => [] as ActionPath[],
+    };
+    return { props, ...render(<ActionCard {...(props as never)} />) };
+  }
+
+  test('pending debounce writes to the CURRENT path after the card shifts', () => {
+    const action: DialogAction = {
+      type: 'DialogLine',
+      speaker: 'other',
+      text: '',
+      id: 'DIA_Arog_Test_15_02',
+    };
+    const updateActionAtPath = jest.fn();
+    const { props, rerender } = renderCard([2], action, updateActionAtPath);
+
+    // Type while the card sits at path [2]; debounce starts.
+    fireEvent.change(screen.getByLabelText('Text'), { target: { value: 'Hello' } });
+
+    // An action gets inserted above before the debounce fires: same action
+    // object, new path [3].
+    rerender(<ActionCard {...({ ...props, path: [3], index: 3 } as never)} />);
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(updateActionAtPath).toHaveBeenCalledTimes(1);
+    const [calledPath, calledAction] = updateActionAtPath.mock.calls[0];
+    expect(calledPath).toEqual([3]);
+    expect(calledAction).toMatchObject({ text: 'Hello' });
+  });
+
+  test('pending debounce writes the latest typed text, not the keystroke snapshot', () => {
+    const action: DialogAction = {
+      type: 'DialogLine',
+      speaker: 'other',
+      text: '',
+      id: 'DIA_Arog_Test_15_03',
+    };
+    const updateActionAtPath = jest.fn();
+    renderCard([1], action, updateActionAtPath);
+
+    const input = screen.getByLabelText('Text');
+    fireEvent.change(input, { target: { value: 'Hel' } });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    fireEvent.change(input, { target: { value: 'Hello world' } });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(updateActionAtPath).toHaveBeenCalledTimes(1);
+    expect(updateActionAtPath.mock.calls[0][1]).toMatchObject({ text: 'Hello world' });
+  });
+});

--- a/daedalus-dialog-editor/tests/e2e/conditional-action-text-loss.spec.ts
+++ b/daedalus-dialog-editor/tests/e2e/conditional-action-text-loss.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Regression tests for issue #145: typing inside an If/Else block and then
+ * using "Add Line" must never drop text the user already entered — neither
+ * from the block's Condition field nor from nested dialog lines.
+ */
+
+const SAMPLE_DIALOG_CONTENT = fs.readFileSync(
+  path.join(__dirname, '../fixtures/sample-dialog.d'),
+  'utf-8'
+);
+
+async function openSampleDialog(page: Page) {
+  await page.goto('/');
+  await page.evaluate((content) => {
+    localStorage.setItem('mockapi_file_test-dialog.d', content);
+  }, SAMPLE_DIALOG_CONTENT);
+
+  page.on('dialog', async (d) => await d.accept('test-dialog.d'));
+  await page.getByRole('button', { name: /Open Single File/i }).click();
+  await expect(page.getByRole('heading', { name: 'NPCs' })).toBeVisible({ timeout: 10000 });
+
+  await page.getByText('SLD_99005_Arog').click();
+  await page.getByRole('button', { name: /DIA_Arog_EntscheidungKillAlchemist/ }).click();
+  await expect(
+    page.getByRole('heading', { name: 'DIA_Arog_EntscheidungKillAlchemist', exact: true })
+  ).toBeVisible();
+  await expect(page.getByLabel('Text').first()).toBeVisible();
+}
+
+async function addConditionalBlock(page: Page) {
+  await page.getByRole('button', { name: 'Add action' }).click();
+  await page.getByPlaceholder('Search actions...').fill('If / Else Block');
+  await page.getByRole('menuitem', { name: 'If / Else Block', exact: true }).click();
+  await expect(page.getByRole('textbox', { name: 'Condition' })).toBeVisible({ timeout: 5000 });
+}
+
+test.describe('Conditional action text preservation (#145)', () => {
+  test.beforeEach(async ({ page }) => {
+    await openSampleDialog(page);
+  });
+
+  test('condition text survives an immediate "Add Line" into the then branch', async ({ page }) => {
+    await addConditionalBlock(page);
+
+    const condition = page.getByRole('textbox', { name: 'Condition' });
+    await condition.click();
+    // Type and click "Add Line" while the 300ms debounce is still pending.
+    await condition.pressSequentially('MIS_Test == LOG_RUNNING');
+    await page.getByRole('button', { name: 'Add Line' }).first().click();
+
+    await page.waitForTimeout(500);
+    await expect(condition).toHaveValue('MIS_Test == LOG_RUNNING');
+    // The new nested line must exist (then branch no longer empty).
+    await expect(page.getByText('No actions in this branch.')).toHaveCount(1);
+  });
+
+  test('nested line text survives adding a line into the other branch', async ({ page }) => {
+    await addConditionalBlock(page);
+
+    // Add a line to the then-branch and type into it.
+    await page.getByRole('button', { name: 'Add Line' }).first().click();
+    const dialogLineFields = page.getByLabel('Text');
+    await expect(dialogLineFields).toHaveCount(4);
+
+    const nestedLine = dialogLineFields.nth(3);
+    await nestedLine.click();
+    await nestedLine.pressSequentially('Hello from the then branch');
+
+    // Immediately add a line into the else branch (within the debounce window).
+    await page.getByRole('button', { name: 'Add Line' }).first().click();
+    await page.waitForTimeout(500);
+
+    await expect(page.getByLabel('Text')).toHaveCount(5);
+    await expect(dialogLineFields.nth(3)).toHaveValue('Hello from the then branch');
+  });
+
+  test('nested line text survives editing the condition afterwards', async ({ page }) => {
+    await addConditionalBlock(page);
+
+    await page.getByRole('button', { name: 'Add Line' }).first().click();
+    const nestedLine = page.getByLabel('Text').nth(3);
+    await nestedLine.click();
+    await nestedLine.pressSequentially('Persistent line');
+
+    // Move straight into the condition field and type while the nested
+    // line's debounce may still be pending.
+    const condition = page.getByRole('textbox', { name: 'Condition' });
+    await condition.click();
+    await condition.pressSequentially('Npc_KnowsInfo(other, DIA_Arog_Hallo)');
+
+    // Add a line to the else branch immediately.
+    await page.getByRole('button', { name: 'Add Line' }).first().click();
+    await page.waitForTimeout(500);
+
+    await expect(condition).toHaveValue('Npc_KnowsInfo(other, DIA_Arog_Hallo)');
+    await expect(page.getByLabel('Text').nth(3)).toHaveValue('Persistent line');
+  });
+
+  test('text typed into a new nested line survives pressing Enter to add another', async ({ page }) => {
+    await addConditionalBlock(page);
+
+    await page.getByRole('button', { name: 'Add Line' }).first().click();
+    const nestedLine = page.getByLabel('Text').nth(3);
+    await nestedLine.click();
+    await nestedLine.pressSequentially('First nested line');
+    await nestedLine.press('Enter');
+
+    await page.waitForTimeout(500);
+    // Enter adds a sibling line inside the same branch.
+    await expect(page.getByLabel('Text')).toHaveCount(5);
+    await expect(page.getByLabel('Text').nth(3)).toHaveValue('First nested line');
+    await expect(page.getByLabel('Text').nth(4)).toHaveValue('');
+  });
+});

--- a/daedalus-dialog-editor/tests/e2e/conditional-action.spec.ts
+++ b/daedalus-dialog-editor/tests/e2e/conditional-action.spec.ts
@@ -79,6 +79,25 @@ test.describe('Conditional action (If / Else block)', () => {
     await expect(page.getByText('No actions in this branch.')).toHaveCount(1);
   });
 
+  test('inserts a "knows info" condition from the template menu (#145)', async ({ page }) => {
+    await addConditionalBlock(page);
+
+    await page.getByRole('button', { name: 'Insert condition template' }).click();
+    await page.getByRole('menuitem', { name: 'NPC Knows Dialog' }).click();
+
+    const condition = page.getByRole('textbox', { name: 'Condition' });
+    await expect(condition).toHaveValue('Npc_KnowsInfo(other, DIA_)');
+
+    // A second template is appended with && instead of replacing.
+    await page.getByRole('button', { name: 'Insert condition template' }).click();
+    await page.getByRole('menuitem', { name: 'Quest State' }).click();
+    await expect(condition).toHaveValue('Npc_KnowsInfo(other, DIA_) && MIS_ == LOG_RUNNING');
+
+    // The inserted condition persists past the debounce window.
+    await page.waitForTimeout(400);
+    await expect(condition).toHaveValue('Npc_KnowsInfo(other, DIA_) && MIS_ == LOG_RUNNING');
+  });
+
   test('adds an action into the "else" branch via the action menu', async ({ page }) => {
     await addConditionalBlock(page);
 


### PR DESCRIPTION
## Summary
- Fix the random text deletion in If/Else blocks (issue #145): the ActionCard debounce timer captured `path` lexically, so when a card shifted while a 300ms sync was pending (insertion above it, undo, drag reorder) the typed text was written onto a **different** action. The timer now resolves path and payload via refs at fire time, mirroring the existing unmount-cleanup pattern.
- Add an "Insert condition template" menu to the If-block condition field for parity with the dialog-level condition editor — including the previously missing **NPC Knows Dialog** (`Npc_KnowsInfo`) option, plus Variable Check, NPC Has Items, NPC Is In State, NPC Is Dead, and Quest State. Templates append with `&&` when a condition already exists.

## Tests
- New component test `tests/ActionCard.debounceStalePath.test.tsx` reproduces the stale-path debounce write (failed before the fix, passes after).
- New E2E spec `tests/e2e/conditional-action-text-loss.spec.ts` with 4 regression scenarios for the reported flows (typing + immediate Add Line in then/else branches, condition edits, Enter-to-add).
- New E2E test in `tests/e2e/conditional-action.spec.ts` for the condition template menu (failing-first).
- `npm run test:stable:windows`: all 78 suites pass. `npm run typecheck:renderer`: clean. All 9 conditional-action E2E tests pass.

Fixes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)
